### PR TITLE
Resource pool and target host no longer have to be specified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,7 @@ driver:
   vcenter_host: vcenter.chef.io
   vcenter_disable_ssl_verify: true
   driver_config:
-    targethost: 172.16.20.41
     datacenter: "Datacenter"
-    resource_pool: "testkitchen"
 
 platforms:
   - name: ubuntu-1604
@@ -73,16 +71,16 @@ The following parameters should be set in the main `driver_config` section as th
 
 The following parameters should be set in the `driver_config` for the individual platform.
 
- - `targethost` - Host on which the new virtual machine should be created
  - `template` - Template or virtual machine to use when cloning the new machine
  - `datacenter` - Name of the datacenter to use to deploy into
- - `resource_pool` - Name of the resource pool to use when creating the machine. The resource pool _must_ already exist
 
 ### Optional Parameters
 
 The following optional parameters should be used in the `driver_config` for the platform.
 
- - `folder` - Folder into which the new machine should be stored. If specified the folder _must_ already exist
+ - `targethost` - Host on which the new virtual machine should be created. If not specified then the first host in the cluster is used.
+ - `folder` - Folder into which the new machine should be stored. If specified the folder _must_ already exist.
+ - `resource_pool` - Name of the resource pool to use when creating the machine. If specified the resource pool _must_ already exist
 
 ## Contributing
 

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -16,6 +16,8 @@ class Support
       dc = vim.serviceInstance.find_datacenter(options[:datacenter])
       src_vm = dc.find_vm(options[:template])
 
+      raise format("Unable to find template: %s", options[:template]) if src_vm.nil?
+
       # Specify where the machine is going to be created
       relocate_spec = RbVmomi::VIM.VirtualMachineRelocateSpec
       relocate_spec.host = options[:targethost]

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -19,6 +19,8 @@ class Support
       # Specify where the machine is going to be created
       relocate_spec = RbVmomi::VIM.VirtualMachineRelocateSpec
       relocate_spec.host = options[:targethost]
+
+      # Set the resource pool
       relocate_spec.pool = options[:resource_pool]
 
       clone_spec = RbVmomi::VIM.VirtualMachineCloneSpec(location: relocate_spec,


### PR DESCRIPTION
### Description

One two parameters _must_ be specified in the driver config section now. These are `datacenter` and `template`.

Updated README.

### Issues Resolved

`targethost`, `resource_pool` and `folder` will be derived if they are not specified as per the following:

`targethost` - first host in cluster used
`resource_pool` - first resource pool in cluster used
`folder` - same folder as the vm / template that the machine was created from.

Looking into the use of DRS to get better recommendations from the cluster as to where new machines should be hosted etc.

/cc @jjasghar 
