### PR TITLE
Update dependency reqs. Update README for dep install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Please refer to the [CHANGELOG](CHANGELOG.md) for version history and known issu
 
 ## Installation
 
+This driver has a dependency. It requires the [vSphere Automation SDK](https://github.com/vmware/vsphere-automation-sdk-ruby) be installed. The steps to do that are as follows:
+
+- git clone [https://github.com/vmware/vsphere-automation-sdk-ruby.git](https://github.com/vmware/vsphere-automation-sdk-ruby.git)
+- cd vsphere-automation-sdk-ruby
+- gem build vsphere-automation-sdk-ruby.gemspec
+- chef gem install vsphere-automation-sdk-<version>.gem
+
 Using [ChefDK](https://downloads.chef.io/chef-dk/), simply install the Gem:
 
 ```bash

--- a/kitchen-vcenter.gemspec
+++ b/kitchen-vcenter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'test-kitchen', '~> 1.16'
-  spec.add_dependency 'vsphere-automation-sdk', '~> 2.5'
+  spec.add_dependency 'vsphere-automation-sdk', '~> 6.6'
   spec.add_dependency 'rbvmomi', '~> 1.11'
   spec.add_dependency 'savon', '~> 2.11'
 


### PR DESCRIPTION
### Description

Update the gemspec requirements to vsphere-automation-sdk 6.6+ (since this is latest version)
Describe in README how to get the SDK installed

### Issues Resolved

#11 

### Check List

- [ ] All tests pass.
- [ ] All style checks pass.
- [ ] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable
