### PR TITLE
Forced specific version of test-kitchen to 1.16.0

### DIFF
--- a/kitchen-vcenter.gemspec
+++ b/kitchen-vcenter.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['LICENSE', 'README.md', 'CHANGELOG.md', 'lib/**/*', 'kitchen-vcenter/version.rb']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'test-kitchen', '~> 1.16'
+  spec.add_dependency 'test-kitchen', '= 1.16.0'
   spec.add_dependency 'vsphere-automation-sdk', '~> 6.6'
   spec.add_dependency 'rbvmomi', '~> 1.11'
   spec.add_dependency 'savon', '~> 2.11'

--- a/kitchen-vcenter.gemspec
+++ b/kitchen-vcenter.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['LICENSE', 'README.md', 'CHANGELOG.md', 'lib/**/*', 'kitchen-vcenter/version.rb']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'test-kitchen', '= 1.16.0'
+  spec.add_dependency 'test-kitchen', '= 1.16'
   spec.add_dependency 'vsphere-automation-sdk', '~> 6.6'
   spec.add_dependency 'rbvmomi', '~> 1.11'
   spec.add_dependency 'savon', '~> 2.11'


### PR DESCRIPTION
### Description

Stops other kitchen drivers and their dependencies from being pulled in, e.g. kitchen-ec2 and and associated aws gems.

It appears that TK 1.17.0 has a dependency that calls all of these because it does not specifically do this.

### Issues Resolved

Allows this driver to run under ChefDK 2.2.x

