### PR TITLE
Fixed behaviour when not having any resource pools (Issue #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The following optional parameters should be used in the `driver_config` for the 
 
  - `targethost` - Host on which the new virtual machine should be created. If not specified then the first host in the cluster is used.
  - `folder` - Folder into which the new machine should be stored. If specified the folder _must_ already exist.
- - `resource_pool` - Name of the resource pool to use when creating the machine. If specified the resource pool _must_ already exist
+ - `resource_pool` - Name of the resource pool to use when creating the machine. Will search first pool by default, can use value 'Resources' for none
 
 ## Contributing
 

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -58,8 +58,6 @@ module Kitchen
           config[:vm_name] = format('%s-%s-%s', instance.suite.name, instance.platform.name, SecureRandom.hex(4))
         end
 
-        # raise "Please set the resource pool name using `resource_pool` parameter in the 'drive_config' section of your .kitchen.yml file" if config[:resource_pool].nil?
-
         connect
 
         # Using the clone class, create a machine for TK
@@ -182,22 +180,30 @@ module Kitchen
 
       # Gets the name of the resource pool
       #
+      # @todo Will not yet work with nested pools ("Pool1/Subpool1")
       # @param [name] name is the name of the ResourcePool
       def get_resource_pool(name)
         # Create a resource pool object
         rp_obj = Com::Vmware::Vcenter::ResourcePool.new(vapi_config)
 
-        # If a name has been set then try to find it, otherwise use the first
-        # resource pool that can be found
+        # If no name has been set, use the first resource pool that can be found,
+        # otherwise try to find by given name
         if name.nil?
-          resource_pool = rp_obj.list
+          # Remove default pool for first pass (<= 1.2.1 behaviour to pick first user-defined pool found)
+          resource_pool = rp_obj.list.delete_if { |pool| pool.name == 'Resources' }
+          debug('Search of all resource pools found: ' + resource_pool.map { |pool| pool.name }.to_s)
+
+          # Revert to default pool, if no user-defined pool found (> 1.2.1 behaviour)
+          # (This one might not be found under some circumstances by the statement above)
+          resource_pool = get_resource_pool('Resources') if resource_pool.empty?
         else
           # create a filter to find the named resource pool
           filter = Com::Vmware::Vcenter::ResourcePool::FilterSpec.new(names: Set.new([name]))
           resource_pool = rp_obj.list(filter)
+          debug('Search for resource pools found: ' + resource_pool.map { |pool| pool.name }.to_s)
         end
 
-        raise format('Unable to find Resource Pool: %s', name) if resource_pool.nil?
+        raise format('Unable to find Resource Pool: %s', name) if resource_pool.empty?
 
         resource_pool[0].resource_pool
       end


### PR DESCRIPTION
### Description

Fixes the need to specify a resource pool.

### Issues Resolved

Issue #28

### Check List

Tested on vSphere 6.5 with a fresh cluster, without resource pools and with user defined pools:
- will use the default "Resources" pool, if no pools are found at all
- will use the first user defined one, if there are pools present but none was specified in config
- will use the specified one, if it exists in config and on cluster
- will exit, if the specified one does not exist