### PR TITLE
Implement support for linked clones (feature #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The following parameters should be set in the main `driver_config` section as th
 
 The following parameters should be set in the `driver_config` for the individual platform.
 
- - `template` - Template or virtual machine to use when cloning the new machine
+ - `template` - Template or virtual machine to use when cloning the new machine (needs to be a VM for linked clones)
  - `datacenter` - Name of the datacenter to use to deploy into
 
 ### Optional Parameters
@@ -124,6 +124,7 @@ The following optional parameters should be used in the `driver_config` for the 
  - `targethost` - Host on which the new virtual machine should be created. If not specified then the first host in the cluster is used.
  - `folder` - Folder into which the new machine should be stored. If specified the folder _must_ already exist.
  - `resource_pool` - Name of the resource pool to use when creating the machine. If specified the resource pool _must_ already exist
+ - `clone_type` - Type of clone, will default to "full" to create complete copies of template. Needs a VM as template parameter, if "linked" clone desired
 
 ## Contributing
 

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -48,6 +48,7 @@ module Kitchen
       default_config :poweron, true
       default_config :vm_name, nil
       default_config :resource_pool, nil
+      default_config :clone_type, :full
 
       # The main create method
       #
@@ -78,6 +79,9 @@ module Kitchen
           id: get_folder(config[:folder]),
         } unless config[:folder].nil?
 
+        # Allow different clone types
+        config[:clone_type] = :linked if config[:clone_type] == 'linked'
+
         # Create a hash of options that the clone requires
         options = {
           name: config[:vm_name],
@@ -87,6 +91,7 @@ module Kitchen
           datacenter: config[:datacenter],
           folder: config[:folder],
           resource_pool: config[:resource_pool],
+          clone_type: config[:clone_type],
         }
 
         # Create an object from which the clone operation can be called

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -22,6 +22,9 @@ class Support
       relocate_spec = RbVmomi::VIM.VirtualMachineRelocateSpec
       relocate_spec.host = options[:targethost]
 
+      # Change to delta disks for linked clones
+      relocate_spec.diskMoveType = :moveChildMostDiskBacking if options[:clone_type] == :linked
+
       # Set the resource pool
       relocate_spec.pool = options[:resource_pool]
 


### PR DESCRIPTION
### Description

Implement linked clones for faster creation of VMs.

### Issues Resolved

New feature.

### Check List

Tested with vSphere 6.5:
- not specifying option will lead to full clone
- specifying "clone_type: full" will lead to a full clone
- specifying "clone_type: linked" on a template will lead to "NotSupported"
- specifying "clone_type: linked" on a VM will lead to a linked clone with delta backings