### PR TITLE
Feature/check parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,19 +109,23 @@ The following parameters should be set in the main `driver_config` section as th
  - `vcenter_username` - Name to use when connecting to the vSphere environment
  - `vcenter_password` - Password associated with the specified user
  - `vcenter_host` - Host against which logins should be attempted
- - `vcenter_disable_ssl_verify` - Whether or not to disable SSL verification checks. Good when using self signed certificates. Default: false
 
 The following parameters should be set in the `driver_config` for the individual platform:
 
- - `template` - Template or virtual machine to use when cloning the new machine (needs to be a VM for linked clones)
  - `datacenter` - Name of the datacenter to use to deploy into
+ - `template` - Template or virtual machine to use when cloning the new machine (needs to be a VM for linked clones)
 
 ### Optional Parameters
+
+The following parameters should be set in the main `driver_config` section as they are common to all platforms:
+ - `vcenter_disable_ssl_verify` - Whether or not to disable SSL verification checks. Good when using self signed certificates. Default: false
 
 The following optional parameters should be used in the `driver_config` for the platform.
 
  - `targethost` - Host on which the new virtual machine should be created. If not specified then the first host in the cluster is used.
  - `folder` - Folder into which the new machine should be stored. If specified the folder _must_ already exist.
+ - `poweron` - Power on the new virtual machine. Default: true
+ - `vm_name` - Specify name of virtual machine. Default: `<suite>-<platform>-<random-hexid>`
  - `resource_pool` - Name of the resource pool to use when creating the machine. Will search first pool by default, can use value 'Resources' for none.
  - `clone_type` - Type of clone, will default to "full" to create complete copies of template. Needs a VM as template parameter, if "linked" clone desired.
 

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -37,13 +37,14 @@ module Kitchen
     class Vcenter < Kitchen::Driver::Base
       attr_accessor :connection_options, :ipaddress, :vapi_config, :session_svc, :session_id
 
-      default_config :targethost
-      default_config :folder
-      default_config :template
-      default_config :datacenter
-      default_config :vcenter_username
-      default_config :vcenter_password
-      default_config :vcenter_host
+      required_config :vcenter_username
+      required_config :vcenter_password
+      required_config :vcenter_host
+      required_config :datacenter
+      required_config :targethost
+      required_config :template
+
+      default_config :folder, nil
       default_config :vcenter_disable_ssl_verify, false
       default_config :poweron, true
       default_config :vm_name, nil

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -41,11 +41,11 @@ module Kitchen
       required_config :vcenter_password
       required_config :vcenter_host
       required_config :datacenter
-      required_config :targethost
       required_config :template
 
-      default_config :folder, nil
       default_config :vcenter_disable_ssl_verify, false
+      default_config :targethost, nil
+      default_config :folder, nil
       default_config :poweron, true
       default_config :vm_name, nil
       default_config :resource_pool, nil


### PR DESCRIPTION
### Description

Clearly marks required parameters, resulting in errors if any are missing.

### Issues Resolved

Before, omitting required parameters would result in cryptic messages upon create/converge such as " Message: Failed to complete #create action: [unexpected path class NilClass]", if a template directive was missing.

Now, this will return "Message: Kitchen::Driver::Vcenter<default-vm>#config[:template] cannot be blank"

Additionally:
- poweron and vm_name parameters were not documented before
- vcenter_disable_ssl_verify was documented as required, but is optional

### Check List

- [X] Functionality has been documented in the README if applicable
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>