### PR TITLE
Require Ruby 2.2+ and slim the files we ship in the gem

### DIFF
--- a/kitchen-vcenter.gemspec
+++ b/kitchen-vcenter.gemspec
@@ -13,8 +13,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chef/kitchen-vcenter"
   spec.license       = "Apache-2.0"
 
-  spec.files         = Dir["LICENSE", "README.md", "CHANGELOG.md", "lib/**/*", "kitchen-vcenter/version.rb"]
+  spec.files         = Dir["LICENSE", "lib/**/*"]
   spec.require_paths = ["lib"]
+
+  s.required_ruby_version = ">= 2.2"
 
   spec.add_dependency "rbvmomi", "~> 1.11"
   spec.add_dependency "savon", "~> 2.11"


### PR DESCRIPTION
Don't ship the readme or changelog in the gem artifact. Also require a mildly modern ruby release.

Signed-off-by: Tim Smith <tsmith@chef.io>