### PR TITLE
Implement change of network backing

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The following optional parameters should be used in the `driver_config` for the 
  - `vm_name` - Specify name of virtual machine. Default: `<suite>-<platform>-<random-hexid>`
  - `clone_type` - Type of clone, use "full" to create complete copies of template. Values: "full", "linked", "instant". Default: "full"
  - `lookup_service_host` - Specify hostname of Lookup Service for setups with external PSC. Default: autodetect
+ - `network_name` - Network to switch first interface to, needs a VM Network name. Default: do not change
 
 Only one of the following optional parameters can be given:
  - `resource_pool` - Name of the resource pool to use when creating the machine. Default: first pool

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -53,6 +53,7 @@ module Kitchen
       default_config :clone_type, :full
       default_config :cluster, nil
       default_config :lookup_service_host, nil
+      default_config :network_name, nil
 
       # The main create method
       #
@@ -94,6 +95,9 @@ module Kitchen
         # Check that the datacenter exists
         datacenter_exists?(config[:datacenter])
 
+        # Check if network exists, if to be changed
+        network_exists?(config[:network_name]) unless config[:network_name].nil?
+
         # Same thing needs to happen with the folder name if it has been set
         unless config[:folder].nil?
           config[:folder] = {
@@ -116,6 +120,7 @@ module Kitchen
           folder: config[:folder],
           resource_pool: config[:resource_pool],
           clone_type: config[:clone_type],
+          network_name: config[:network_name],
         }
 
         # Create an object from which the clone operation can be called
@@ -165,6 +170,17 @@ module Kitchen
         dc = dc_obj.list(filter)
 
         raise format("Unable to find data center: %s", name) if dc.empty?
+      end
+
+      # Checks if a network exists or not
+      #
+      # @param [name] name is the name of the Network
+      def network_exists?(name)
+        net_obj = Com::Vmware::Vcenter::Network.new(vapi_config)
+        filter = Com::Vmware::Vcenter::Network::FilterSpec.new(names: Set.new([name]))
+        net = net_obj.list(filter)
+
+        raise format("Unable to find target network: %s", name) if net.empty?
       end
 
       # Validates the host name of the server you can connect to

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -30,6 +30,26 @@ class Support
       # Set the resource pool
       relocate_spec.pool = options[:resource_pool]
 
+      # Change network, if wanted
+      unless options[:network_name].nil?
+        all_network_devices = src_vm.config.hardware.device.select do |device|
+          device.is_a?(RbVmomi::VIM::VirtualEthernetCard)
+        end
+
+        # Only support for first NIC so far
+        network_device = all_network_devices.first
+        network_device.backing = RbVmomi::VIM.VirtualEthernetCardNetworkBackingInfo(
+          deviceName: options[:network_name]
+        )
+
+        relocate_spec.deviceChange = [
+          RbVmomi::VIM.VirtualDeviceConfigSpec(
+            operation: RbVmomi::VIM::VirtualDeviceConfigSpecOperation("edit"),
+            device: network_device
+          )
+        ]
+      end
+
       # Set the folder to use
       dest_folder = options[:folder].nil? ? src_vm.parent : options[:folder][:id]
 


### PR DESCRIPTION
### Description

Add ability to move the created VM onto another network via using the "network_name" parameter.

### Issues Resolved

Implements feature request #21

### Check List

- [X] All style checks pass.
- [X] Functionality has been documented in the README if applicable
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>