### PR TITLE
Allow template names to include a VM folder path

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ platforms:
   - name: windows2012R2
     driver_config:
       targethost: 10.0.0.42
-      template: windows2012R2-template
+      template: folder/windows2012R2-template
       datacenter: "Datacenter"
     transport:
       username: "Administrator"

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -14,8 +14,11 @@ class Support
     def clone
       # set the datacenter name
       dc = vim.serviceInstance.find_datacenter(options[:datacenter])
-      src_vm = dc.find_vm(options[:template])
 
+      # reference template using full inventory path
+      root_folder = @vim.serviceInstance.content.rootFolder
+      inventory_path = format('/%s/vm/%s', options[:datacenter], options[:template])
+      src_vm = root_folder.findByInventoryPath(inventory_path)
       raise format("Unable to find template: %s", options[:template]) if src_vm.nil?
 
       # Specify where the machine is going to be created

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -54,7 +54,7 @@ class Support
       end
 
       # Set the folder to use
-      dest_folder = options[:folder].nil? ? src_vm.parent : options[:folder][:id]
+      dest_folder = options[:folder].nil? ? dc.vmFolder : options[:folder][:id]
 
       puts "Cloning '#{options[:template]}' to create the VM..."
       if options[:clone_type] == :instant

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -17,7 +17,7 @@ class Support
 
       # reference template using full inventory path
       root_folder = @vim.serviceInstance.content.rootFolder
-      inventory_path = format('/%s/vm/%s', options[:datacenter], options[:template])
+      inventory_path = format("/%s/vm/%s", options[:datacenter], options[:template])
       src_vm = root_folder.findByInventoryPath(inventory_path)
       raise format("Unable to find template: %s", options[:template]) if src_vm.nil?
 


### PR DESCRIPTION
### Description

VMs or templates to be cloned can now be inside of folders or subfolders.

### Issues Resolved

Until now, templates or VMs to be cloned had to be placed in the vSphere's datacenter root directly. For better organization, most setups use folders to group templates - often being nested several levels deep.

Due to the find_vm method being non-recursive, using anything within folders was not possible before (#29). By converting the lookup to use the inventory path instead (format: "DATACENTER/vm/FOLDER/VM"), this now provides the ability to use both templates within the datacenter root (just as before) as well as within subfolders.

### Check List

- [X] All style checks pass.
- [X] Functionality has been documented in the README if applicable
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>