### PR TITLE
Updating installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please refer to the [CHANGELOG](CHANGELOG.md) for version history and known issu
 
 ## Installation
 
-This driver has a dependency. It requires the [vSphere Automation SDK](https://github.com/vmware/vsphere-automation-sdk-ruby) be installed. The steps to do that are as follows, the version published to Rubygems is not yet supported. For the time being you need to build the gem to a previous commit.
+This driver depends on the [vSphere Automation SDK](https://github.com/vmware/vsphere-automation-sdk-ruby) gem. We do not yet support version published on RubyGems, and you will need to build an earlier version of the gem. Install the vSphere Automation SDK gem with the following steps:
 
 - `$ git clone` [https://github.com/vmware/vsphere-automation-sdk-ruby.git](https://github.com/vmware/vsphere-automation-sdk-ruby.git)
 - `cd vsphere-automation-sdk-ruby`

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ Please refer to the [CHANGELOG](CHANGELOG.md) for version history and known issu
 
 ## Installation
 
-This driver has a dependency. It requires the [vSphere Automation SDK](https://github.com/vmware/vsphere-automation-sdk-ruby) be installed. The steps to do that are as follows, for the time being it's not published to Rubygems. If you are interested, please comment [here](https://github.com/vmware/vsphere-automation-sdk-ruby/issues/10).
+This driver has a dependency. It requires the [vSphere Automation SDK](https://github.com/vmware/vsphere-automation-sdk-ruby) be installed. The steps to do that are as follows, the version published to Rubygems is not yet supported. For the time being you need to build the gem to a previous commit.
 
 - `$ git clone` [https://github.com/vmware/vsphere-automation-sdk-ruby.git](https://github.com/vmware/vsphere-automation-sdk-ruby.git)
 - `cd vsphere-automation-sdk-ruby`
-- `gem build vsphere-automation-sdk-ruby.gemspec`
-- `chef gem install vsphere-automation-sdk-<version>.gem`
+- `git checkout 2ffd6f9e2bcde899a6f5f863d5de97e38135fcd2`
+- `chef gem build vsphere-automation-sdk-ruby.gemspec`
+- `chef gem install vsphere-automation-sdk-6.6.1.gem`
 
 Using [ChefDK](https://downloads.chef.io/chef-dk/), simply install the Gem:
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Please refer to the [CHANGELOG](CHANGELOG.md) for version history and known issu
 
 This driver depends on the [vSphere Automation SDK](https://github.com/vmware/vsphere-automation-sdk-ruby) gem. We do not yet support version published on RubyGems, and you will need to build an earlier version of the gem. Install the vSphere Automation SDK gem with the following steps:
 
-- `$ git clone` [https://github.com/vmware/vsphere-automation-sdk-ruby.git](https://github.com/vmware/vsphere-automation-sdk-ruby.git)
-- `cd vsphere-automation-sdk-ruby`
-- `git checkout 2ffd6f9e2bcde899a6f5f863d5de97e38135fcd2`
-- `chef gem build vsphere-automation-sdk-ruby.gemspec`
-- `chef gem install vsphere-automation-sdk-6.6.1.gem`
+1. `$ git clone` [https://github.com/vmware/vsphere-automation-sdk-ruby.git](https://github.com/vmware/vsphere-automation-sdk-ruby.git)
+2. `cd vsphere-automation-sdk-ruby`
+3. `git checkout 2ffd6f9e2bcde899a6f5f863d5de97e38135fcd2`
+4. `chef gem build vsphere-automation-sdk-ruby.gemspec`
+5. `chef gem install vsphere-automation-sdk-6.6.1.gem`
 
 Using [ChefDK](https://downloads.chef.io/chef-dk/), simply install the Gem:
 


### PR DESCRIPTION

### Description

Since `vsphere-automation-sdk` has been released **yesterday** to Rubygems with a version ~ 0.1.0, and the openapi branch merged, I assume no-one has tested this with `kitchen-vcenter` yet.
Building as instructed now builds 0.1.0 (and makes `gem install kitchen-vcenter` fails the dependency requirement).
I looked for a previous commit where the version was ~ 6.6.x as per current `kitchen-vcenter` dependency requirements, this commit is the last by @jjasghar so I assume it's been tested with `kitchen-vcenter` (but feel free to change it).

Compilation works, installing kitchen-vcenter works, but I haven't tested it against my vcsa yet.

Hope that helps.

### Issues Resolved

Installation procedure