### PR TITLE
Add feature to tag kitchen instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The following optional parameters should be used in the `driver_config` for the 
  - `clone_type` - Type of clone, use "full" to create complete copies of template. Values: "full", "linked", "instant". Default: "full"
  - `lookup_service_host` - Specify hostname of Lookup Service for setups with external PSC. Default: autodetect
  - `network_name` - Network to switch first interface to, needs a VM Network name. Default: do not change
+ - `tags` - Array of pre-defined vCenter tag names to assign (VMware tags are not key/value pairs). Default: none
 
 Only one of the following optional parameters can be given:
  - `resource_pool` - Name of the resource pool to use when creating the machine. Default: first pool


### PR DESCRIPTION
### Description

Add the ability to mark kitchen VMs with VMware tags.

Please note, that in contrast to e.g. the kitchen-ec2 driver, VMware tags are not key/value but predefined tags grouped in a hierarchy. If different drivers are mixed within a configuration file, the tags attribute should be specified on the platform level instead and not the global level.

### Issues Resolved

Allows easy selection of kitchen VMs in vCenter or excluding them from automatic backup/DR systems.

### Check List

- [X] All style checks pass.
- [X] Functionality has been documented in the README if applicable
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>