### PR TITLE
Implementation of configurable timeouts and automatic rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ The following parameters should be set in the `driver_config` for the individual
 
 The following parameters should be set in the main `driver_config` section as they are common to all platforms:
  - `vcenter_disable_ssl_verify` - Whether or not to disable SSL verification checks. Good when using self signed certificates. Default: false
+ - `vm_wait_timeout` - How many seconds to wait for VM connectivity. Default: 90
+ - `vm_wait_interval` - Check interval between tries on VM connectivity. Default: 2.0
+ - `vm_rollback` - Whether to roll back (destroy) VMs which failed VM connectivity checking. Default: false
 
 The following optional parameters should be used in the `driver_config` for the platform.
 

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -56,6 +56,8 @@ module Kitchen
       default_config :lookup_service_host, nil
       default_config :network_name, nil
       default_config :tags, nil
+      default_config :vm_wait_timeout, 90
+      default_config :vm_wait_interval, 2.0
 
       # The main create method
       #
@@ -108,6 +110,8 @@ module Kitchen
           resource_pool: config[:resource_pool],
           clone_type: config[:clone_type],
           network_name: config[:network_name],
+          wait_timeout: config[:vm_wait_timeout],
+          wait_interval: config[:vm_wait_interval],
         }
 
         # Create an object from which the clone operation can be called

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -34,7 +34,7 @@ class Support
       end
 
       raise "Timeout waiting for IP address or no VMware Tools installed on guest" if ip.nil?
-      raise format("Error getting accessible IP address, got %s. Check DHCP server", ip) if ip =~ /^169\.254\./
+      raise format("Error getting accessible IP address, got %s. Check DHCP server and scope exhaustion", ip) if ip =~ /^169\.254\./
 
       ip
     end

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -11,6 +11,34 @@ class Support
       @vim ||= RbVmomi::VIM.connect conn_opts
     end
 
+    def get_ip(vm)
+      ip = nil
+
+      unless vm.guest.net.empty? || !vm.guest.ipAddress
+        ip = vm.guest.net[0].ipConfig.ipAddress.detect do |addr|
+          addr.origin != "linklayer"
+        end.ipAddress
+      end
+
+      ip
+    end
+
+    def wait_for_ip(vm, timeout = 30.0, interval = 2.0)
+      start = Time.new
+
+      ip = nil
+      loop do
+        ip = get_ip(vm)
+        break if ip || (Time.new - start) >= timeout
+        sleep interval
+      end
+
+      raise "Timeout waiting for IP address or no VMware Tools installed on guest" if ip.nil?
+      raise format("Error getting accessible IP address, got %s. Check DHCP server", ip) if ip =~ /^169\.254\./
+
+      ip
+    end
+
     def clone
       # set the datacenter name
       dc = vim.serviceInstance.find_datacenter(options[:datacenter])
@@ -103,11 +131,12 @@ class Support
       if new_vm.nil?
         puts format("Unable to find machine: %s", name)
       else
-        puts "Waiting for network interfaces to become available..."
-        sleep 2 while new_vm.guest.net.empty? || !new_vm.guest.ipAddress
-        new_vm.guest.net[0].ipConfig.ipAddress.detect do |addr|
-          addr.origin != "linklayer"
-        end.ipAddress
+        puts format("Waiting for VMware tools/network interfaces to become available (timeout: %d seconds)...", options[:wait_timeout])
+
+        ip = wait_for_ip(new_vm, options[:wait_timeout], options[:wait_interval])
+        puts format("Created machine %s with IP %s", name, ip)
+
+        ip
       end
     end
   end


### PR DESCRIPTION
### Description

This patch implements a timeout on waiting for the VM IP address, makes the timeout configurable and adds hints about possible error causes (e.g. VMware tools not being installed, DHCP being unavailable or probable DHCP scope exhaustion).

It also implements an option to automatically remove VMs which failed the connectivity check. These previously cluttered the vCenter service, consumed unnecessary resources and had to be manually cleaned by vCenter administrators from time to time.

A handy addition is the output of the vCenter VM name and IP address for troubleshooting.

### Issues Resolved

No issues so far (but would've been worthy of several)

### Check List

- [X] All style checks pass.
- [X] Functionality has been documented in the README if applicable
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>