### PR TITLE
Implementation of configurable timeouts and automatic rollback (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ The following parameters should be set in the `driver_config` for the individual
 
 The following parameters should be set in the main `driver_config` section as they are common to all platforms:
  - `vcenter_disable_ssl_verify` - Whether or not to disable SSL verification checks. Good when using self signed certificates. Default: false
+ - `vm_wait_timeout` - How many seconds to wait for VM connectivity. Default: 90
+ - `vm_wait_interval` - Check interval between tries on VM connectivity. Default: 2.0
+ - `vm_rollback` - Whether to roll back (destroy) VMs which failed VM connectivity checking. Default: false
 
 The following optional parameters should be used in the `driver_config` for the platform.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The following parameters should be set in the `driver_config` for the individual
 
 The following parameters should be set in the main `driver_config` section as they are common to all platforms:
  - `vcenter_disable_ssl_verify` - Whether or not to disable SSL verification checks. Good when using self signed certificates. Default: false
- - `vm_wait_timeout` - How many seconds to wait for VM connectivity. Default: 90
+ - `vm_wait_timeout` - Number of seconds to wait for VM connectivity. Default: 90
  - `vm_wait_interval` - Check interval between tries on VM connectivity. Default: 2.0
  - `vm_rollback` - Whether to roll back (destroy) VMs which failed VM connectivity checking. Default: false
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The following parameters should be set in the main `driver_config` section as th
  - `vcenter_disable_ssl_verify` - Whether or not to disable SSL verification checks. Good when using self signed certificates. Default: false
  - `vm_wait_timeout` - Number of seconds to wait for VM connectivity. Default: 90
  - `vm_wait_interval` - Check interval between tries on VM connectivity. Default: 2.0
- - `vm_rollback` - Whether to roll back (destroy) VMs which failed VM connectivity checking. Default: false
+ - `vm_rollback` - Automatic roll back (destroy) of VMs failing the connectivity check. Default: false
 
 The following optional parameters should be used in the `driver_config` for the platform.
 

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -118,9 +118,9 @@ module Kitchen
           if config[:vm_rollback] == true
             error format("Rolling back VM %s after critical error", config[:vm_name])
 
-            # Inject name of failed VM and reset the auto-discovered resource pool to clear validation in line #200
+            # Inject name of failed VM for destroy to work
             state[:vm_name] = config[:vm_name]
-            config[:resource_pool] = nil
+
             destroy(state)
           end
 
@@ -161,6 +161,10 @@ module Kitchen
       # @param [Object] state is the state of the vm
       def destroy(state)
         return if state[:vm_name].nil?
+
+        # Reset resource pool, as it's not needed for the destroy action but might be a remnant of earlier calls to "connect"
+        # Temporary fix until setting cluster + resource_pool at the same time is implemented (lines #64/#187)
+        config[:resource_pool] = nil
 
         save_and_validate_parameters
         connect

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -48,6 +48,9 @@ module Kitchen
       default_config :cluster, nil
       default_config :network_name, nil
       default_config :tags, nil
+      default_config :vm_wait_timeout, 90
+      default_config :vm_wait_interval, 2.0
+      default_config :vm_rollback, false
 
       # The main create method
       #
@@ -99,14 +102,28 @@ module Kitchen
           resource_pool: config[:resource_pool],
           clone_type: config[:clone_type],
           network_name: config[:network_name],
+          wait_timeout: config[:vm_wait_timeout],
+          wait_interval: config[:vm_wait_interval],
         }
 
-        # Create an object from which the clone operation can be called
-        new_vm = Support::CloneVm.new(connection_options, options)
-        new_vm.clone
+        begin
+          # Create an object from which the clone operation can be called
+          new_vm = Support::CloneVm.new(connection_options, options)
+          new_vm.clone
 
-        state[:hostname] = new_vm.ip
-        state[:vm_name] = new_vm.name
+          state[:hostname] = new_vm.ip
+          state[:vm_name] = new_vm.name
+
+        rescue # Kitchen::ActionFailed => e
+          if config[:vm_rollback] == true
+            error format("Rolling back VM %s after critical error", config[:vm_name])
+
+            state[:vm_name] = config[:vm_name]
+            destroy(state)
+          end
+
+          raise
+        end
 
         unless config[:tags].nil? || config[:tags].empty?
           tag_api = VSphereAutomation::CIS::TaggingTagApi.new(api_client)

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -118,7 +118,9 @@ module Kitchen
           if config[:vm_rollback] == true
             error format("Rolling back VM %s after critical error", config[:vm_name])
 
+            # Inject name of failed VM and reset the auto-discovered resource pool to clear validation in line #200
             state[:vm_name] = config[:vm_name]
+            config[:resource_pool] = nil
             destroy(state)
           end
 


### PR DESCRIPTION
### Description

**Rewrite of PR #54 for kitchen-vcenter v2**

This patch implements a timeout on waiting for the VM IP address, makes the timeout configurable and adds hints about possible error causes (e.g. VMware tools not being installed, DHCP being unavailable or probable DHCP scope exhaustion).

It also implements an option to automatically remove VMs which failed the connectivity check. These previously cluttered the vCenter service, consumed unnecessary resources and had to be manually cleaned by vCenter administrators from time to time.

Handy additions are outputting the VM name and its IP address for troubleshooting and the use of proper logging for the cloning operation itself.

An additional fix for circumstances where ESX hosts in clusters were not found before is also included.

### Issues Resolved

No related tickets.

### Check List

- [X] All style checks pass.
- [X] Functionality has been documented in the README if applicable
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>