### PR TITLE
Implement reconfiguration of VM memory/CPUs and other parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ driver:
   vcenter_password: <%= ENV['VCENTER_PASSWORD'] %>
   vcenter_host:  <%= ENV['VCENTER_HOST'] %>
   vcenter_disable_ssl_verify: true
+  customize:
+    annotation: "Kitchen VM by <%= ENV['USER'] %> on <%= Time.now.to_s %>"
 
 provisioner:
   name: chef_zero
@@ -89,6 +91,9 @@ platforms:
       network: "Internal"
       template: folder/windows2012R2-template
       datacenter: "Datacenter"
+      customize:
+        numCPUs: 4
+        memoryMB: 1024
     transport:
       username: "Administrator"
       password: "p@ssW0rd!"
@@ -129,6 +134,7 @@ The following optional parameters should be used in the `driver_config` for the 
  - `clone_type` - Type of clone, use "full" to create complete copies of template. Values: "full", "linked", "instant". Default: "full"
  - `network_name` - Network to switch first interface to, needs a VM Network name. Default: do not change
  - `tags` - Array of pre-defined vCenter tag names to assign (VMware tags are not key/value pairs). Default: none
+ - `customize` - Dictionary of `xsd:*`-type customizations like annotation, memoryMB or numCPUs (see [VirtualMachineConfigSpec](https://pubs.vmware.com/vsphere-6-5/index.jsp?topic=%2Fcom.vmware.wssdk.smssdk.doc%2Fvim.vm.ConfigSpec.html)). Default: none
 
 Only one of the following optional parameters can be given:
  - `resource_pool` - Name of the resource pool to use when creating the machine. Default: first pool

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -51,6 +51,7 @@ module Kitchen
       default_config :vm_wait_timeout, 90
       default_config :vm_wait_interval, 2.0
       default_config :vm_rollback, false
+      default_config :customize, nil
 
       # The main create method
       #
@@ -104,6 +105,7 @@ module Kitchen
           network_name: config[:network_name],
           wait_timeout: config[:vm_wait_timeout],
           wait_interval: config[:vm_wait_interval],
+          customize: config[:customize],
         }
 
         begin


### PR DESCRIPTION
### Description

Enable reconfiguration of VM parameters to allocate more RAM or change CPU/core settings. This also allows setting annotations for created machines, so they can include a hint on who created an instance and when. An example is included in the README.md file.

All supplied parameters get passed through directly to the VMware API, so all settings with type xsd:* from https://pubs.vmware.com/vsphere-6-5/index.jsp?topic=%2Fcom.vmware.wssdk.smssdk.doc%2Fvim.vm.ConfigSpec.html are usable

Most common should be:
- annotation
- memoryMB
- numCoresPerSocket
- numCPUs

### Issues Resolved

No related tickets are open, customer requests for this functionality have been common.

### Check List

- [X] All style checks pass.
- [X] Functionality has been documented in the README if applicable
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>