### PR TITLE
Network Interface Selection Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ platforms:
     driver:
       targethost: 10.0.0.42
       template: ubuntu16-template
+      interface: "VM Network"
       datacenter: "Datacenter"
     transport:
       username: "admini"
@@ -88,7 +89,7 @@ platforms:
   - name: windows2012R2
     driver:
       targethost: 10.0.0.42
-      network: "Internal"
+      network_name: "Internal"
       template: folder/windows2012R2-template
       datacenter: "Datacenter"
       customize:
@@ -134,9 +135,10 @@ The following optional parameters should be used in the `driver_config` for the 
  - `poweron` - Power on the new virtual machine. Default: true
  - `vm_name` - Specify name of virtual machine. Default: `<suite>-<platform>-<random-hexid>`
  - `clone_type` - Type of clone, use "full" to create complete copies of template. Values: "full", "linked", "instant". Default: "full"
- - `network_name` - Network to switch first interface to, needs a VM Network name. Default: do not change
+ - `network_name` - Network to reconfigure the first interface to, needs a VM Network name. Default: do not change
  - `tags` - Array of pre-defined vCenter tag names to assign (VMware tags are not key/value pairs). Default: none
  - `customize` - Dictionary of `xsd:*`-type customizations like annotation, memoryMB or numCPUs (see [VirtualMachineConfigSpec](https://pubs.vmware.com/vsphere-6-5/index.jsp?topic=%2Fcom.vmware.wssdk.smssdk.doc%2Fvim.vm.ConfigSpec.html)). Default: none
+ - `interface`- VM Network name to use for kitchen connections. Default: not set = first interface with usable IP
 
 ## Clone types
 

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -52,6 +52,7 @@ module Kitchen
       default_config :vm_wait_interval, 2.0
       default_config :vm_rollback, false
       default_config :customize, nil
+      default_config :interface, nil
 
       # The main create method
       #
@@ -118,6 +119,7 @@ module Kitchen
           resource_pool: config[:resource_pool],
           clone_type: config[:clone_type],
           network_name: config[:network_name],
+          interface: config[:interface],
           wait_timeout: config[:vm_wait_timeout],
           wait_interval: config[:vm_wait_interval],
           customize: config[:customize],

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -27,11 +27,11 @@ class Support
 
         vm_ip = nil
         nics.each do |net|
-          vm_ip = net.ipConfig.ipAddress.detect { |addr| addr.origin != 'linklayer' }
+          vm_ip = net.ipConfig.ipAddress.detect { |addr| addr.origin != "linklayer" }
           break unless vm_ip.nil?
         end
 
-        extended_msg = options[:interface] ? 'Network ' + options[:interface] : ''
+        extended_msg = options[:interface] ? "Network #{options[:interface]}" : ""
         raise format("No valid IP found on VM %s", extended_msg) if vm_ip.nil?
 
         @ip = vm_ip.ipAddress

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -16,10 +16,25 @@ class Support
     def get_ip(vm)
       @ip = nil
 
+      # Don't simply use vm.guest.ipAddress to allow specifying a different interface
       unless vm.guest.net.empty? || !vm.guest.ipAddress
-        @ip = vm.guest.net[0].ipConfig.ipAddress.detect do |addr|
-          addr.origin != "linklayer"
-        end.ipAddress
+        nics = vm.guest.net
+        if options[:interface]
+          nics.select! { |nic| nic.network == options[:interface] }
+
+          raise format("No interfaces found on VM which are attached to network '%s'", options[:interface]) if nics.empty?
+        end
+
+        vm_ip = nil
+        nics.each do |net|
+          vm_ip = net.ipConfig.ipAddress.detect { |addr| addr.origin != 'linklayer' }
+          break unless vm_ip.nil?
+        end
+
+        extended_msg = options[:interface] ? 'Network ' + options[:interface] : ''
+        raise format("No valid IP found on VM %s", extended_msg) if vm_ip.nil?
+
+        @ip = vm_ip.ipAddress
       end
 
       ip


### PR DESCRIPTION
### Description

This patch improves support for templates/VMs with more than one network interface. Previously, IPs would only be pulled off the first interface on the machine. If this interface was on the wrong network or had no IP assigned, VM creation would fail.  Now, you can specify the name of the VM Network to use for kitchen connectivity via the `interface` parameter.

In addition, even with multiple interfaces, the first non link-local address of the machine is used. That way, disconnected interfaces will not cause provisioning to fail.

Includes a small fix to documentation: The example in README.md did state "network" instead of "network_name" for reconfiguring the first network interface.

### Issues Resolved

No existing issues, just some conversations on Slack.

### Check List

- [X] All style checks pass.
- [X] Functionality has been documented in the README if applicable
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>