### PR TITLE
Fix instant clones, which failed after implementing VM reconfiguration

### DIFF
--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -167,7 +167,7 @@ class Support
         task.wait_for_completion
       end
 
-      if options[:poweron] && !options[:customize].nil?
+      if options[:poweron] && !options[:customize].nil? && options[:clone_type] != :instant
         task = vm.PowerOnVM_Task
         task.wait_for_completion
       end


### PR DESCRIPTION
### Description

Forgot a small check after adding support for VM reconfiguration via `customize`. As instant clones are already booted up at the point of their creation, trying to switch them on a second time would crash.

### Issues Resolved

No public issues

### Check List

- [X] All style checks pass.
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>