### PR TITLE
Loosen the Test Kitchen dep to allow 2.X

### DIFF
--- a/kitchen-vcenter.gemspec
+++ b/kitchen-vcenter.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rbvmomi", "~> 1.11"
   spec.add_dependency "savon", "~> 2.11"
-  spec.add_dependency "test-kitchen", "~> 1.16"
+  spec.add_dependency "test-kitchen", ">= 1.16", "< 3.0"
   spec.add_dependency "vsphere-automation-sdk", "~> 0.1"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
2.X has no impact on this plugin

Signed-off-by: Tim Smith <tsmith@chef.io>