### PR TITLE
Improve loose target host and folder filters

### DIFF
--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -58,6 +58,7 @@ class Support
           return
         end
         break if (Time.new - start) >= timeout
+
         sleep interval
       end
 
@@ -178,7 +179,7 @@ class Support
           RbVmomi::VIM.VirtualDeviceConfigSpec(
             operation: RbVmomi::VIM::VirtualDeviceConfigSpecOperation("edit"),
             device: network_device
-          )
+          ),
         ]
       )
 
@@ -212,7 +213,7 @@ class Support
         return [
           "/sbin/modprobe -r vmxnet3",
           "/sbin/modprobe vmxnet3",
-          "/sbin/dhclient"
+          "/sbin/dhclient",
         ]
       when :windows
         return [
@@ -229,7 +230,7 @@ class Support
       case options[:vm_os].downcase.to_sym
       when :linux
         [
-          "/usr/bin/vmware-toolbox-cmd info update network"
+          "/usr/bin/vmware-toolbox-cmd info update network",
         ]
       when :windows
         [
@@ -386,7 +387,7 @@ class Support
           RbVmomi::VIM.VirtualDeviceConfigSpec(
             operation: RbVmomi::VIM::VirtualDeviceConfigSpecOperation("edit"),
             device: network_device
-          )
+          ),
         ]
       end
 
@@ -397,15 +398,17 @@ class Support
       if instant_clone?
         vcenter_data = vim.serviceInstance.content.about
         raise Support::CloneError.new("Instant clones only supported with vCenter 6.7 or higher") unless vcenter_data.version.to_f >= 6.7
+
         Kitchen.logger.debug format("Detected %s", vcenter_data.fullName)
 
         resources = dc.hostFolder.children
-        hosts = resources.select { |resource| resource.class.to_s =~ /ComputeResource$/ }.map { |c| c.host }.flatten
+        hosts = resources.select { |resource| resource.class.to_s =~ /ComputeResource$/ }.map(&:host).flatten
         targethost = hosts.select { |host| host.summary.config.name == options[:targethost].name }.first
         raise Support::CloneError.new("No matching ComputeResource found in host folder") if targethost.nil?
 
         esx_data = targethost.summary.config.product
         raise Support::CloneError.new("Instant clones only supported with ESX 6.7 or higher") unless esx_data.version.to_f >= 6.7
+
         Kitchen.logger.debug format("Detected %s", esx_data.fullName)
 
         # Other tools check for VMWare Tools status, but that will be toolsNotRunning on frozen VMs
@@ -431,7 +434,7 @@ class Support
           RbVmomi::VIM.VirtualDeviceConfigSpec(
             operation: RbVmomi::VIM::VirtualDeviceConfigSpecOperation("edit"),
             device: network_device
-          )
+          ),
         ]
 
         clone_spec = RbVmomi::VIM.VirtualMachineInstantCloneSpec(location: relocate_spec,

--- a/lib/support/guest_operations.rb
+++ b/lib/support/guest_operations.rb
@@ -47,6 +47,7 @@ class Support
       loop do
         return unless process_is_running(pid)
         break if (Time.new - start) >= timeout
+
         sleep interval
       end
 


### PR DESCRIPTION
### Description

These fixes are for some assumptions that have been made that are not necessarily true on more complex vcenter installations, and were causing issues:

- target host names are not necessarily unique across clusters and datacenters.
The filter when searching for them in get_host needs to include cluster and datacenter; we need a host that has access to the resource pool specified, not the first host that matches that could be in any cluster.
It is also better to return a random host in the set of target hosts when more than one is matched, for better load balancing.

- folders names are also not necessarily unique, need to filter for the right type ("VIRTUAL_MACHINE" }
Once again this broke where there were multiple folders with the same name, but different types; the driver returned the incorrect one as it picked the first off the list returned.

### Issues Resolved

No open issue

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG