### PR TITLE
Fix error if no clusters are defined or targethost is not a member

### DIFF
--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -304,7 +304,7 @@ module Kitchen
       # Validates the host name of the server you can connect to
       #
       # @param [name] name is the name of the host
-      def get_host(name, datacenter, cluster)
+      def get_host(name, datacenter, cluster = nil)
         # create a host object to work with
         host_api = VSphereAutomation::VCenter::HostApi.new(api_client)
 
@@ -360,6 +360,8 @@ module Kitchen
       #
       # @param [name] name is the name of the Cluster
       def get_cluster_id(name)
+        return nil if name.nil?
+
         cluster_api = VSphereAutomation::VCenter::ClusterApi.new(api_client)
         clusters = cluster_api.list({ filter_names: name }).value
 


### PR DESCRIPTION
### Description

Fix the error if no clusters are defined ("Unable to find Cluster") or targethost is not a member of a cluster ("Unable to find target host").

Before, not finding a matching cluster would raise an exception. Now, the lookup will return `nil` which is ignored in the `VSphereAutomation::VCenter::HostApi#list` filter expression.

Also changed the `cluster` parameter to function `get_host` to default to `nil` to make this more obvious.

### Issues Resolved

Fixes issue #74 

### Check List

- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [X] PR title is a worthy inclusion in the CHANGELOG