### PR TITLE
Update to allow for the new rbvmomi

### DIFF
--- a/kitchen-vcenter.gemspec
+++ b/kitchen-vcenter.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3"
 
-  spec.add_dependency "rbvmomi", "~> 1.11"
+  spec.add_dependency "rbvmomi", ">= 1.11", "< 3.0"
   spec.add_dependency "savon", "~> 2.11"
   spec.add_dependency "test-kitchen", ">= 1.16", "< 3.0"
-  spec.add_dependency "vsphere-automation-sdk", "~> 0.1"
+  spec.add_dependency "vsphere-automation-sdk", "~> 0.4"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
The new version switches from trollop to optimist since trollop is
deprecated.

Signed-off-by: Tim Smith <tsmith@chef.io>