### PR TITLE
Fallback to datacenter lookup that requires less privileges

### DIFF
--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -395,15 +395,34 @@ class Support
       options[:clone_type] == :full
     end
 
+    def root_folder
+      @root_folder ||= vim.serviceInstance.content.rootFolder
+    end
+
+    #
+    # @return [String]
+    #
+    def datacenter
+      options[:datacenter]
+    end
+
+    #
+    # @return [RbVmomi::VIM::Datacenter]
+    #
+    def find_datacenter
+      vim.serviceInstance.find_datacenter(datacenter)
+    rescue RbVmomi::Fault
+      root_folder.childEntity.grep(RbVmomi::VIM::Datacenter).find { |x| x.name == datacenter }
+    end
+
     def clone
       benchmark_start if benchmark?
 
       # set the datacenter name
-      dc = vim.serviceInstance.find_datacenter(options[:datacenter])
+      dc = find_datacenter
 
       # reference template using full inventory path
-      root_folder = vim.serviceInstance.content.rootFolder
-      inventory_path = format("/%s/vm/%s", options[:datacenter], options[:template])
+      inventory_path = format("/%s/vm/%s", datacenter, options[:template])
       src_vm = root_folder.findByInventoryPath(inventory_path)
       raise Support::CloneError.new(format("Unable to find template: %s", options[:template])) if src_vm.nil?
 


### PR DESCRIPTION
### Description

Fixes a permission issue in environments where least privilege principle is in use

```text
NoPermission: Permission to perform this operation was denied.
```

I just copied the solution discussed here:

- https://github.com/CenturyLinkCloud/chef-provisioning-vsphere/pull/55
- https://github.com/CenturyLinkCloud/chef-provisioning-vsphere/issues/34

N/A

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG