### PR TITLE
declare network_device var in the correct scope

### DIFF
--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -436,6 +436,7 @@ class Support
 
         Kitchen.logger.warn format("Found %d networks named %s, picking first one", networks.count, options[:network_name]) if networks.count > 1
         network_obj = networks.first
+        network_device = network_device(src_vm)
 
         if network_obj.is_a? RbVmomi::VIM::DistributedVirtualPortgroup
           Kitchen.logger.info format("Assigning network %s...", network_obj.pretty_path)
@@ -443,7 +444,6 @@ class Support
           vds_obj = network_obj.config.distributedVirtualSwitch
           Kitchen.logger.info format("Using vDS '%s' for network connectivity...", vds_obj.name)
 
-          network_device = network_device(src_vm)
           network_device.backing = RbVmomi::VIM.VirtualEthernetCardDistributedVirtualPortBackingInfo(
             port: RbVmomi::VIM.DistributedVirtualSwitchPortConnection(
               portgroupKey: network_obj.key,


### PR DESCRIPTION
Signed-off-by: Will Fisher <wfisher@chef.io>

### Description

The `network_device` variable was being declared in the wrong scope and throws errors if `network_name` is used in `kitchen.yml`

It looks like this bug was introduced in #70 

```
>>>>>>     Failed to complete #create action: [undefined method `backing=' for nil:NilClass] on default-windows2016
D      ------Backtrace-------
D      C:/Users/rwilk/AppData/Local/chefdk/gem/ruby/2.6.0/gems/kitchen-vcenter-2.6.0/lib/support/clone_vm.rb:456:in `clone'
D      C:/Users/rwilk/AppData/Local/chefdk/gem/ruby/2.6.0/gems/kitchen-vcenter-2.6.0/lib/kitchen/driver/vcenter.rb:168:in `create'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/instance.rb:485:in `public_send'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/instance.rb:485:in `block in perform_action'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/instance.rb:552:in `synchronize_or_call'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/instance.rb:514:in `block in action'
D      C:/opscode/chef-workstation/embedded/lib/ruby/2.6.0/benchmark.rb:293:in `measure'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/instance.rb:513:in `action'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/instance.rb:485:in `perform_action'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/instance.rb:394:in `create_action'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/instance.rb:382:in `block (2 levels) in transition_to'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/lifecycle_hooks.rb:45:in `run_with_hooks'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/instance.rb:381:in `block in transition_to'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/instance.rb:380:in `each'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/instance.rb:380:in `transition_to'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/instance.rb:129:in `create'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/command.rb:198:in `public_send'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/command.rb:198:in `run_action_in_thread'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/test-kitchen-2.3.4/lib/kitchen/command.rb:169:in `block (2 levels) in run_action'
D      C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/logging-2.2.2/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'
D      ----End Backtrace-----
```

### Issues Resolved


### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG