### PR TITLE
Fix active discovery command

### DIFF
--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -251,6 +251,8 @@ class Support
           # "wmic nicconfig get IPAddress",
           # "netsh interface ip show ipaddress #{options[:vm_win_network]}"
         end
+      else
+        return options[:active_discovery_command]
       end
     end
 

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -251,7 +251,7 @@ class Support
           # "wmic nicconfig get IPAddress",
           # "netsh interface ip show ipaddress #{options[:vm_win_network]}"
         end
-      else
+      else 
         return options[:active_discovery_command]
       end
     end

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -251,7 +251,7 @@ class Support
           # "wmic nicconfig get IPAddress",
           # "netsh interface ip show ipaddress #{options[:vm_win_network]}"
         end
-      else 
+      else  
         return options[:active_discovery_command]
       end
     end


### PR DESCRIPTION
### Description

This fixes the active_discovery_command error "Active discovery failed: can't convert nil into Integer" when trying to use the property on the kitchen.yml

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG

Author: Leonardo Tagliabue <leotaglia@gmail.com>

  Fix return value on function.

  Obvious fix.