### PR TITLE
Fix reference to undefined variable in CloneError message

### DIFF
--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -432,7 +432,7 @@ class Support
       # Change network, if wanted
       unless options[:network_name].nil?
         networks = dc.network.select { |n| n.name == options[:network_name] }
-        raise Support::CloneError.new(format("Could not find network named %s", option[:network_name])) if networks.empty?
+        raise Support::CloneError.new(format("Could not find network named %s", options[:network_name])) if networks.empty?
 
         Kitchen.logger.warn format("Found %d networks named %s, picking first one", networks.count, options[:network_name]) if networks.count > 1
         network_obj = networks.first


### PR DESCRIPTION
### Description

When configuring the vcenter driver with a network that doesn't exist,
the expected `CloneError` doesn't get thrown correctly because the error
message it's building incorrectly references the `options` hash as
`option`, which yields an undefined local variable or method error
instead.

Signed-off-by: Keith Walters <kwalters@taphere.com>

### Issues Resolved

This fix is not for any existing issue documented on Github

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG