### PR TITLE
Add ability to transform VM IP for 1:1 NAT environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The following parameters should be set in the main `driver` section as they are 
  - `vm_rollback` - Automatic roll back (destroy) of VMs failing the connectivity check. Default: false
  - `benchmark` - Write benchmark data for comparisons. Default: false
  - `benchmark_file` - Filename to write CSV data to. Default: "kitchen-vcenter.csv"
+ - `transform_ip` - Ruby code to rewrite instance IP (available as `ip` variable in contents)
 
 The following optional parameters should be used in the `driver` for the platform.
 
@@ -259,6 +260,25 @@ enable this via the `benchmark` property, data gets appended to a CSV file (`ben
 This file includes a header line describing the different fields such as the value of `template`, `clone_type` and `active_discovery` plus the different
 steps within cloning a VM. The timing of steps is relative to each other and followed by a column with the total number of seconds for the whole cloning
 operation.
+
+## 1:1 NAT Support
+
+Due to limited IPv4 space, some enterprises use NAT to transform the VM IPs into a routable IP. As the driver cannot detect such a NAT automatically,
+but has to rely on the IP retrieved by the Guest OS, this has to be handled manually.
+
+Example:
+```
+driver:
+  # ... other settings
+  network_name: TEST-NET
+  transform_ip: "ip.sub '172.16.', '10.25.'"
+```
+
+This example reassociates the VM to the separate VMware network "TEST-NET", which would provision addresses from 172.16.x.x to the VMs. In between
+this network and the developers, there is a router with 1:1 NAT configured so that those machines will be reachable as 10.25.x.x externally.
+
+Any passed Ruby code will be executed with the `ip` variable (as discovered by VMware) available. The returned value will then be used as new IP.
+As you can use arbitrary Ruby code, it is possible to do complex arithmetics or even implement remote API/IPAM lookups.
 
 ## Contributing
 

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -18,6 +18,7 @@
 require "kitchen"
 require "vsphere-automation-cis"
 require "vsphere-automation-vcenter"
+require_relative "../../kitchen-vcenter/version"
 require_relative "../../support/clone_vm"
 require "securerandom"
 require "uri"
@@ -57,6 +58,7 @@ module Kitchen
       default_config :vm_username, "vagrant"
       default_config :vm_password, "vagrant"
       default_config :vm_win_network, "Ethernet0"
+      default_config :transform_ip, nil
 
       default_config :benchmark, false
       default_config :benchmark_file, "kitchen-vcenter.csv"
@@ -82,6 +84,8 @@ module Kitchen
       #
       # @param [Object] state is the state of the vm
       def create(state)
+        debug format("Starting kitchen-vcenter %s", ::KitchenVcenter::VERSION)
+
         save_and_validate_parameters
         connect
 
@@ -158,6 +162,7 @@ module Kitchen
           vm_username: config[:vm_username],
           vm_password: config[:vm_password],
           vm_win_network: config[:vm_win_network],
+          transform_ip: config[:transform_ip],
           benchmark: config[:benchmark],
           benchmark_file: config[:benchmark_file],
         }

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -81,6 +81,17 @@ class Support
       raise Support::CloneError.new("Timeout waiting for IP address") if ip.nil?
       raise Support::CloneError.new(format("Error getting accessible IP address, got %s. Check DHCP server and scope exhaustion", ip)) if ip =~ /^169\.254\./
 
+      # Allow IP rewriting (e.g. for 1:1 NAT)
+      if options[:transform_ip]
+        Kitchen.logger.info format("Received IP: %s", ip)
+
+        # rubocop:disable Security/Eval
+        ip = lambda { eval options[:transform_ip] }.call
+        # rubocop:enable Security/Eval
+
+        Kitchen.logger.info format("Transformed to IP: %s", ip)
+      end
+
       @ip = ip
     end
 
@@ -251,8 +262,8 @@ class Support
           # "wmic nicconfig get IPAddress",
           # "netsh interface ip show ipaddress #{options[:vm_win_network]}"
         end
-      else  
-        return options[:active_discovery_command]
+      else
+        options[:active_discovery_command]
       end
     end
 


### PR DESCRIPTION
### Description

Due to internal IP shortages, some enterprise customers deploy subnets for test machines but need to NAT them 1:1 for use due to routing. This can result in a VM getting the IP 172.16.3.5 internally but it being reachable as 10.201.7.133 to the developer instead using 1:1 NAT.

This PR adds a property to the driver which enables users to supply some Ruby transformation code. Transforming the VM IP is not always a simple search-and-replace operation, but may involve IP arithmetic or even external lookups.

### Issues Resolved

No issues filed yet, but customer requirements/blockers are known.

### Check List

- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [X] PR title is a worthy inclusion in the CHANGELOG