### PR TITLE
Implement post_create_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Windows default:
 
 ## Post Create Script
 
-This offers a way to make VMs ready for connections by a TestKitchen transport. In some cases, the default firewall settings will not allow immediate
+This offers a way to make VMs ready for connections by a Test Kitchen transport. In some cases, the default firewall settings will not allow immediate
 connections via WinRM. With a post create script, you can remotely execute statements to enable this.
 
 Add all necessary commands with the `post_create_script` property. These commands get invoked via the Guest Operations API (VMware Tools), which does not

--- a/README.md
+++ b/README.md
@@ -255,20 +255,20 @@ Linux default:
 Windows default:
 `sleep 5 & ipconfig`
 
-## Post Create Script
+## Post-Create Script
 
-This offers a way to make VMs ready for connections by a Test Kitchen transport. In some cases, the default firewall settings will not allow immediate
-connections via WinRM. With a post create script, you can remotely execute statements to enable this.
+Post-create scripts offer a way to make VMs ready for connections by a Test Kitchen transport.
+In some cases, the default firewall settings block immediate connections through WinRM. Post-create scripts let you remotely execute commands to enable immediate access through WinRM.
 
-Add all necessary commands with the `post_create_script` property. These commands get invoked via the Guest Operations API (VMware Tools), which does not
-require network connectivity. As such, they need additional privileges in vCenter.
+Add all of the required commands for enabling WinRM connections with the `post_create_script` property.
+The Guest Operations API (VMware Tools) executes the commands from the `post_create_script`. The GuestOperatons endpoint does not require network connectivity, but it does require additional privileges in vCenter.
 
-Needed privileges:
+Enable these privileges in vCenter:
 - VirtualMachine.GuestOperations.Execute
 - VirtualMachine.GuestOperations.Query
 
-The commands gets executed with the credentials specified for the transport, but can be overridden via `vm_username` and `vm_password`. The default
-timeout is 60 seconds, but can be adjusted via `post_create_script_timeout`.
+The commands are executed with the credentials specified for the transport, which you can override with `vm_username` and `vm_password`.
+The `post_create_script` default timeout is 60 seconds. Configure the timeout with `post_create_script_timeout`.
 
 ## Benchmarking
 
@@ -298,8 +298,8 @@ this network and the developers, there is a router with 1:1 NAT configured so th
 Any passed Ruby code will be executed with the `ip` variable (as discovered by VMware) available. The returned value will then be used as new IP.
 As you can use arbitrary Ruby code, it is possible to do complex arithmetics or even implement remote API/IPAM lookups.
 
-Windows by default does only allow WinRM connections from the local subnet. In a 1:1 NAT situation, you either have to open up the firewall before,
-when creating the template, or you can use a post create script like this:
+The Windows default behavior allows only WinRM connections from the local subnet.
+There are two options for a 1:1 NAT situation, either open up the firewall at the time you create the template or open it with a post-create script, for example:
 
 ```
 platforms:

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -55,10 +55,12 @@ module Kitchen
       default_config :active_discovery, false
       default_config :active_discovery_command, nil
       default_config :vm_os, nil
-      default_config :vm_username, "vagrant"
-      default_config :vm_password, "vagrant"
+      default_config :vm_username, nil
+      default_config :vm_password, nil
       default_config :vm_win_network, "Ethernet0"
       default_config :transform_ip, nil
+      default_config :post_create_script, nil
+      default_config :post_create_script_timeout, 60
 
       default_config :benchmark, false
       default_config :benchmark_file, "kitchen-vcenter.csv"
@@ -163,6 +165,8 @@ module Kitchen
           vm_password: config[:vm_password],
           vm_win_network: config[:vm_win_network],
           transform_ip: config[:transform_ip],
+          post_create_script: config[:post_create_script],
+          post_create_script_timeout: config[:post_create_script_timeout],
           benchmark: config[:benchmark],
           benchmark_file: config[:benchmark_file],
         }


### PR DESCRIPTION
### Description

In some cases, remote machines need to get brought into a certain condition before Kitchen can even connect to them. A strong use case might be opening firewalls for WinRM connections:

Customers should use production-grade images in Test Kitchen to achieve Dev/Prod Parity, so changing the firewall in the template is not desired. On the other hand, Kitchen cannot connect before the firewall allows it. By using the VMware Tools Guest Operations API (just as with the Active IP Discovery already present in the driver), such modifications can be made even before network connections are attached.

The solution would also offer the possibility to assign static IPs etc with some scripting. It creates a list of scripts to run, so future features can queue commands as well.

Additionally in this PR:
- use the credentials from the SSH/WinRM transport to connect to VMware Tools by default, can be overridden as before.
  This makes the feature easier to use, as the credentials for both are likely identical.
- switched `benchmark_*` methods to use guards instead of littering `if` around.
  In the mid-term, this driver will need a plugin system to not include too many exotic features and make it testable. That's why I started cleaning the main control flow to be linear and pulled the logic into guards. I will open an issue for the discussion of plugins later.

### Issues Resolved

Issue #69 is kind of relevant, but setting hostname/IP is better done with Guest customization. This PR would offer a way to automate it before that feature lands, though.

### Check List

- [ ] New functionality includes tests
- [X] All tests pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [X] PR title is a worthy inclusion in the CHANGELOG