### PR TITLE
Enable Guest OS customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ platforms:
         subnet_mask: 255.255.252.0
         dns_domain: 'example.com'
         timezone: 'US/Pacific'
-        dns_serverList:
+        dns_server_list:
         - 8.8.8.8
         - 7.7.7.7
         dns_suffix_list:

--- a/README.md
+++ b/README.md
@@ -166,15 +166,16 @@ The following `customize` subkeys are available. They inherit from the specified
  - `add_disks` - Array of disks to add to the VM (requires VirtualMachine.Config.AddNewDisk).
    Keys per disk: `type` (default: `thin`, other values: `flat`/`flat_lazy` or `flat_eager`), `size_mb` in MB (default: 10 GB)
 
-The following `guest_customization` subkeys are available. To configure the guest OS you must define all of the provided parameters. Below the parameters is an example of their usage in a platform driver configuration.
+The following `guest_customization` subkeys are available for Linux guest OS customization. To configure the guest OS you must define all of the provided parameters. Below the parameters is an example of their usage in a platform driver configuration.
+**Note: Does not currently support Windows guest OS customization**
 
- - `ipAddress` - String for configuring a static IPv4 address (performs validation as IPv4 only is supported at this time)
+ - `ip_address` - String for configuring a static IPv4 address (performs validation as IPv4 only is supported at this time)
  - `gateway` - Array for configuring IPv4 addresses as gateways
- - `subnetMask` - String for configuring subnet mask
- - `dnsDomain` - String for configuring DNS domain
+ - `subnet_mask` - String for configuring subnet mask
+ - `dns_domain` - String for configuring DNS domain
  - `timezone` - String for configuring timezone
- - `dnsServerList` - Array for configuring DNS servers
- - `dnsSuffixList` - Array for configuring DNS suffixes
+ - `dns_server_sist` - Array for configuring DNS servers
+ - `dns_suffix_list` - Array for configuring DNS suffixes
 
 ```yml
 platforms:
@@ -187,16 +188,16 @@ platforms:
       poweron: true
       vm_name: centos-7-kitchen
       guest_customization:
-        ipAddress: 10.10.176.15
+        ip_address: 10.10.176.15
         gateway:
         - 17.10.176.1
-        subnetMask: 255.255.252.0
-        dnsDomain: 'example.com'
+        subnet_mask: 255.255.252.0
+        dns_domain: 'example.com'
         timezone: 'US/Pacific'
-        dnsServerList:
+        dns_serverList:
         - 8.8.8.8
         - 7.7.7.7
-        dnsSuffixList:
+        dns_suffix_list:
         - 'test.example.com'
         - 'example.com'
     transport:

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The following `guest_customization` subkeys are available for Linux guest OS cus
  - `subnet_mask` - String for configuring subnet mask
  - `dns_domain` - String for configuring DNS domain
  - `timezone` - String for configuring timezone
- - `dns_server_sist` - Array for configuring DNS servers
+ - `dns_server_list` - Array for configuring DNS servers
  - `dns_suffix_list` - Array for configuring DNS suffixes
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -166,6 +166,44 @@ The following `customize` subkeys are available. They inherit from the specified
  - `add_disks` - Array of disks to add to the VM (requires VirtualMachine.Config.AddNewDisk).
    Keys per disk: `type` (default: `thin`, other values: `flat`/`flat_lazy` or `flat_eager`), `size_mb` in MB (default: 10 GB)
 
+The following `guest_customization` subkeys are available. To configure the guest OS you must define all of the provided parameters. Below the parameters is an example of their usage in a platform driver configuration.
+
+ - `ipAddress` - String for configuring a static IPv4 address (performs validation as IPv4 only is supported at this time)
+ - `gateway` - Array for configuring IPv4 addresses as gateways
+ - `subnetMask` - String for configuring subnet mask
+ - `dnsDomain` - String for configuring DNS domain
+ - `timezone` - String for configuring timezone
+ - `dnsServerList` - Array for configuring DNS servers
+ - `dnsSuffixList` - Array for configuring DNS suffixes
+
+```yml
+platforms:
+  - name: centos-7
+    driver:
+      datacenter: 'Datacenter'
+      template: 'centos-7-template'
+      cluster: 'Kitchen'
+      interface: 'Kitchen Network'
+      poweron: true
+      vm_name: centos-7-kitchen
+      guest_customization:
+        ipAddress: 10.10.176.15
+        gateway:
+        - 17.10.176.1
+        subnetMask: 255.255.252.0
+        dnsDomain: 'example.com'
+        timezone: 'US/Pacific'
+        dnsServerList:
+        - 8.8.8.8
+        - 7.7.7.7
+        dnsSuffixList:
+        - 'test.example.com'
+        - 'example.com'
+    transport:
+      username: "root"
+      password: "<%= ENV['ROOT_PASSWORD']%>"
+```
+
 ## Clone types
 
 ### Clone type: full
@@ -303,6 +341,7 @@ Pull requests are very welcome! Make sure your patches are well tested. Ideally 
 Author:: Russell Seymour ([rseymour@chef.io](mailto:rseymour@chef.io))
 Author:: JJ Asghar ([jj@chef.io](mailto:jj@chef.io))
 Author:: Thomas Heinen ([theinen@tecracer.de](mailto:theinen@tecracer.de))
+Author:: Michael Kennedy ([michael_l_kennedy@me.com](mailto:michael_l_kennedy@me.com))
 
 Copyright:: Copyright (c) 2017-2019 Chef Software, Inc.
 

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -51,6 +51,7 @@ module Kitchen
       default_config :vm_wait_interval, 2.0
       default_config :vm_rollback, false
       default_config :customize, nil
+      default_config :guest_customization, nil
       default_config :interface, nil
       default_config :active_discovery, false
       default_config :active_discovery_command, nil
@@ -156,6 +157,7 @@ module Kitchen
           wait_timeout: config[:vm_wait_timeout],
           wait_interval: config[:vm_wait_interval],
           customize: config[:customize],
+          guest_customization: config[:guest_customization],
           active_discovery: config[:active_discovery],
           active_discovery_command: config[:active_discovery_command],
           vm_os: config[:vm_os],


### PR DESCRIPTION
### Description

This change enables the use of the GuestCustomizationSpec that the vCenter API makes available to configure networking related configurations. This is ideal for environments where DHCP is not available and not preferred as it allows for static IP assignment.

### Issues Resolved

https://github.com/chef/kitchen-vcenter/issues/69, https://github.com/chef/kitchen-vcenter/issues/72

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG