### PR TITLE
Include folder name when looking up datacenter

### DIFF
--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -221,13 +221,13 @@ class Support
       case options[:vm_os].downcase.to_sym
       when :linux
         # @todo: allow override if no dhclient
-        return [
+        [
           "/sbin/modprobe -r vmxnet3",
           "/sbin/modprobe vmxnet3",
           "/sbin/dhclient",
         ]
       when :windows
-        return [
+        [
           "netsh interface set Interface #{options[:vm_win_network]} disable",
           "netsh interface set Interface #{options[:vm_win_network]} enable",
           "ipconfig /renew",


### PR DESCRIPTION
### Description

If the user stores their datacenters in folders in their inventory, then specifies the datacenter using the full folder path, kitchen-vcenter will fail to locate the datacenter. This is because the underlying API only looks for the datacenter name, not the folder path. 

This PR updates the datacenter existence check and ID lookup to also filter on the folder ID, if the folder is provided.

### Issues Resolved

Fixes #95

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG