### PR TITLE
(fix) Allow nested folders to be created

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The following optional parameters should be used in the `driver` for the platfor
  - `resource_pool` - Name of the resource pool to use when creating the machine. Default: first pool
  - `cluster` - Cluster on which the new virtual machine should be created. Default: cluster of the `targethost` machine.
  - `targethost` - Host on which the new virtual machine should be created. If not specified then the first host in the cluster is used.
- - `folder` - Folder into which the new machine should be stored. If specified the folder _must_ already exist.
+ - `folder` - Folder into which the new machine should be stored. If the `folder` value contains a `/` then a full-path must be specified and allows nested folders to be used. If specified the folder _must_ already exist.
  - `poweron` - Power on the new virtual machine. Default: true
  - `vm_name` - Specify name of virtual machine. Default: `<suite>-<platform>-<random-hexid>`
  - `clone_type` - Type of clone, use "full" to create complete copies of template. Values: "full", "linked", "instant". Default: "full"

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -337,6 +337,16 @@ module Kitchen
       # @param [type] type is the type of the folder, one of VIRTUAL_MACHINE, DATACENTER, possibly other values
       def get_folder(name, type = "VIRTUAL_MACHINE")
         folder_api = VSphereAutomation::VCenter::FolderApi.new(api_client)
+
+        # Handle sub-folders
+        if name.include? "/"
+          folder_stack = name.split("/").reject(&:empty?)
+          name = folder_stack.pop
+          folders = folder_api.list({ parent_folders: folder_stack, filter_names: name, filter_type: type }).value
+        else
+          folders = folder_api.list({ filter_names: name, filter_type: type }).value
+        end
+
         folders = folder_api.list({ filter_names: name, filter_type: type }).value
 
         raise format("Unable to find folder: %s", name) if folders.empty?


### PR DESCRIPTION
## Description
Allow full path to VM Folder creation to be specified.
Only tested against simple nesting (e.g. `FolderB/SubFolder1`) in this setup:
-FolderA
    -SubFolder1
-FolderB
    -SubFolder1

## Related Issue
This should address issue chef#93.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).



Signed-off-by: Peter Beresford <peter.beresford@beazley.com>