### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ rescue LoadError
   puts "chefstyle gem is not installed. bundle install first to make sure all dependencies are installed."
 end
 
-require "yard"
+require "yard" unless defined?(YARD)
 
 RuboCop::RakeTask.new(:style)
 YARD::Rake::YardocTask.new do |t|

--- a/lib/kitchen/driver/vcenter.rb
+++ b/lib/kitchen/driver/vcenter.rb
@@ -20,8 +20,8 @@ require "vsphere-automation-cis"
 require "vsphere-automation-vcenter"
 require_relative "../../kitchen-vcenter/version"
 require_relative "../../support/clone_vm"
-require "securerandom"
-require "uri"
+require "securerandom" unless defined?(SecureRandom)
+require "uri" unless defined?(URI)
 
 # The main kitchen module
 module Kitchen

--- a/lib/support/guest_operations.rb
+++ b/lib/support/guest_operations.rb
@@ -1,5 +1,5 @@
 require "rbvmomi"
-require "net/http"
+require "net/http" unless defined?(Net::HTTP)
 
 class Support
   # Encapsulate VMware Tools GOM interaction, inspired by github:dnuffer/raidopt


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>