### PR TITLE
Support datacenters in folders when falling back in dc lookup

### DIFF
--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -425,7 +425,10 @@ class Support
     def find_datacenter
       vim.serviceInstance.find_datacenter(datacenter)
     rescue RbVmomi::Fault
-      root_folder.childEntity.grep(RbVmomi::VIM::Datacenter).find { |x| x.name == datacenter }
+      dc = root_folder.findByInventoryPath(datacenter)
+      return dc if dc.is_a?(RbVmomi::VIM::Datacenter)
+
+      raise Support::CloneError.new("Unable to locate datacenter at '#{datacenter}'")
     end
 
     def ip?(string)


### PR DESCRIPTION
## Description

Followup to #98 

When looking up the Datacenter object in the support code, if the first attempt fails, the fallback code assumed the datacenter was an immediate child of the root folder. This is not true for sites that store their datacenters in folders. This change looks up the datacenter using `findByInventoryPath` and then verifies that what it found really is a Datacenter (as opposed to a folder or similar).



<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
