### PR TITLE
Add windows password customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The following `guest_customization` subkeys are Windows specific:
 
  - `org_name` - (_Optional_) Organization name for the Machine. Default: "TestKitchen"
  - `product_id` - (_Required_) Product Key for the OS. Default: Attempt automatic selection, but this might fail
- - `password` - (_Optional_) The plain text password to assign to the 'Administrator' account during customization
+ - `administrator_password` - (_Optional_) The plain text password to assign to the 'Administrator' account during customization
 
 On guest customizations after Windows Vista the machine SID will be regenerated to avoid conflicts.
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The following `guest_customization` subkeys are Windows specific:
 
  - `org_name` - (_Optional_) Organization name for the Machine. Default: "TestKitchen"
  - `product_id` - (_Required_) Product Key for the OS. Default: Attempt automatic selection, but this might fail
+ - `password` - (_Optional_) The plain text password to assign to the 'Administrator' account during customization
 
 On guest customizations after Windows Vista the machine SID will be regenerated to avoid conflicts.
 

--- a/lib/support/guest_customization.rb
+++ b/lib/support/guest_customization.rb
@@ -186,10 +186,10 @@ class Support
       end
 
       customization_pass = nil
-      if guest_customization[:password]
+      if guest_customization[:administrator_password]
         customization_pass = RbVmomi::VIM::CustomizationPassword.new(
           plainText: true,
-          value: guest_customization[:password]
+          value: guest_customization[:administrator_password]
         )
       end
 

--- a/lib/support/guest_customization.rb
+++ b/lib/support/guest_customization.rb
@@ -185,11 +185,20 @@ class Support
         ERROR
       end
 
+      customization_pass = nil
+      if guest_customization[:password]
+        customization_pass = RbVmomi::VIM::CustomizationPassword.new(
+          plainText: true,
+          value: guest_customization[:password]
+        )
+      end
+
       RbVmomi::VIM::CustomizationSysprep.new(
         guiUnattended: RbVmomi::VIM::CustomizationGuiUnattended.new(
           timeZone: timezone.to_i || DEFAULT_WINDOWS_TIMEZONE,
           autoLogon: false,
-          autoLogonCount: 1
+          autoLogonCount: 1,
+          password: customization_pass
         ),
         identification: RbVmomi::VIM::CustomizationIdentification.new,
         userData: RbVmomi::VIM::CustomizationUserData.new(


### PR DESCRIPTION
Add ability to specify administrator password during guest customization of windows VMs

## Description
Allows configuring a password on the default administrator account of the cloned VM during guest customization

## Related Issue
#135 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
