### PR TITLE
Remove EOL Ruby 2.5 references

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -10,14 +10,6 @@ expeditor:
       timeout_in_minutes: 30
 
 steps:
-- label: run-lint-and-specs-ruby-2.5
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-buster
-
 - label: run-lint-and-specs-ruby-2.6
   command:
     - .expeditor/run_linux_tests.sh rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,2 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6

--- a/Gemfile
+++ b/Gemfile
@@ -6,16 +6,11 @@ group :development do
   gem "rake"
   gem "rspec"
   gem "chefstyle", "2.1.0"
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6") # Remove this entirely once Ruby 2.5 support ends
-    gem "chef-utils", "< 16.7"
-  end
 end
 
 group :debug do
   gem "pry"
   gem "pry-byebug"
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6") # Remove this pin once Ruby 2.5 support ends
-    gem "pry-stack_explorer", "< 0.5"
-  end
+  gem "pry-stack_explorer"
   gem "rb-readline"
 end

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please refer to the [CHANGELOG](CHANGELOG.md) for version history and known issu
 
 ## Requirements
 
-- Ruby 2.5 or higher
+- Ruby 2.6 or higher
 - VMware vCenter/vSphere 5.5 or higher
 - VMs or templates to clone, with open-vm-tools installed
 - DHCP server to assign IPs to kitchen instances

--- a/kitchen-vcenter.gemspec
+++ b/kitchen-vcenter.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["LICENSE", "lib/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.6"
 
   spec.add_dependency "net-ping", ">= 2.0.0", "< 3.0"
   spec.add_dependency "rbvmomi", ">= 1.11", "< 4.0"


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

## Description
Updated verify pipeline execution paths, gem dependencies, readme and rubycop baseline version. Now minimum Ruby version supported is v2.6.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
