### PR TITLE
Support for adding new NIC while cloning the vm

### DIFF
--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -520,7 +520,7 @@ class Support
         RbVmomi::VIM.VirtualDeviceConfigSpec(
           operation: RbVmomi::VIM::VirtualDeviceConfigSpecOperation(operation),
           device: network_device
-        )
+        ),
       ]
     end
 
@@ -533,13 +533,13 @@ class Support
         key: 0,
         deviceInfo: {
           label: options[:network_name],
-          summary: options[:network_name]
+          summary: options[:network_name],
         }
       )
 
       config_spec = RbVmomi::VIM.VirtualMachineConfigSpec(
         {
-          deviceChange: network_change_spec(network_device, network_obj, operation: :add)
+          deviceChange: network_change_spec(network_device, network_obj, operation: :add),
         }
       )
 

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -173,6 +173,14 @@ class Support
       options[:vm_os].downcase.to_sym == :linux
     end
 
+    def update_network?(network_device)
+      options[:network_name] && network_device
+    end
+
+    def add_network?(network_device)
+      options[:network_name] && network_device.nil?
+    end
+
     def network_device(vm)
       all_network_devices = vm.config.hardware.device.select do |device|
         device.is_a?(RbVmomi::VIM::VirtualEthernetCard)
@@ -463,6 +471,83 @@ class Support
       ))
     end
 
+    # This method will fetch the network which is configured in the kitchen.yml file with
+    # network_name configuration.
+    # If there are multiple networks with the same name, first one will be used.
+    #
+    # @return Network object
+    #
+    def fetch_network(datacenter)
+      networks = datacenter.network.select { |n| n.name == options[:network_name] }
+      raise Support::CloneError, format("Could not find network named %s", options[:network_name]) if networks.empty?
+
+      if networks.count > 1
+        Kitchen.logger.warn(
+          format("Found %d networks named %s, picking first one", networks.count, options[:network_name])
+        )
+      end
+      networks.first
+    end
+
+    # This is a helper method that can be used to create the deviceChange spec which can be used
+    # to add a new network device or update the existing network device
+    #
+    # The network_obj will be used as a backing for the network_device.
+    def network_change_spec(network_device, network_obj, operation: :edit)
+      case network_obj
+      when RbVmomi::VIM::DistributedVirtualPortgroup
+        Kitchen.logger.info format("Assigning network %s...", network_obj.pretty_path)
+
+        vds_obj = network_obj.config.distributedVirtualSwitch
+        Kitchen.logger.info format("Using vDS '%s' for network connectivity...", vds_obj.name)
+
+        network_device.backing = RbVmomi::VIM.VirtualEthernetCardDistributedVirtualPortBackingInfo(
+          port: RbVmomi::VIM.DistributedVirtualSwitchPortConnection(
+            portgroupKey: network_obj.key,
+            switchUuid: vds_obj.uuid
+          )
+        )
+      when RbVmomi::VIM::Network
+        Kitchen.logger.info format("Assigning network %s...", options[:network_name])
+
+        network_device.backing = RbVmomi::VIM.VirtualEthernetCardNetworkBackingInfo(
+          deviceName: options[:network_name]
+        )
+      else
+        raise Support::CloneError, format("Unknown network type %s for network name %s", network_obj.class.to_s, options[:network_name])
+      end
+
+      [
+        RbVmomi::VIM.VirtualDeviceConfigSpec(
+          operation: RbVmomi::VIM::VirtualDeviceConfigSpecOperation(operation),
+          device: network_device
+        )
+      ]
+    end
+
+    # This method can be used to add new network device to the target vm
+    # This fill find the network which defined in kitchen.yml in network_name configuration
+    # and attach that to the target vm.
+    def add_new_network_device(datacenter)
+      network_obj = fetch_network(datacenter)
+      network_device = RbVmomi::VIM.VirtualVmxnet3(
+        key: 0,
+        deviceInfo: {
+          label: options[:network_name],
+          summary: options[:network_name]
+        }
+      )
+
+      config_spec = RbVmomi::VIM.VirtualMachineConfigSpec(
+        {
+          deviceChange: network_change_spec(network_device, network_obj, operation: :add)
+        }
+      )
+
+      task = vm.ReconfigVM_Task(spec: config_spec)
+      task.wait_for_completion
+    end
+
     def clone
       benchmark_start if benchmark?
 
@@ -507,64 +592,9 @@ class Support
       network_device = network_device(src_vm)
       Kitchen.logger.warn format("Source VM/template does not have any network device (use VMware IPPools and vsphere-gom transport or govc to access)") unless network_device
 
-      # If the network_name option is set, perform add/update network operation
-      unless options[:network_name].nil?
-        networks = dc.network.select { |n| n.name == options[:network_name] }
-        raise Support::CloneError.new(format("Could not find network named %s", options[:network_name])) if networks.empty?
-
-        Kitchen.logger.warn format("Found %d networks named %s, picking first one", networks.count, options[:network_name]) if networks.count > 1
-        network_obj = networks.first
-
-        # This will add new network to the cloned vm
-        if network_device.nil?
-          relocate_spec.deviceChange = [
-            RbVmomi::VIM.VirtualDeviceConfigSpec(
-              fileOperation: :create,
-              operation: RbVmomi::VIM::VirtualDeviceConfigSpecOperation(:add),
-              device: RbVmomi::VIM.VirtualVmxnet3(
-                key: 0,
-                deviceInfo: {
-                  label: network_obj.name,
-                  summary: 'new device' # TODO: For testing
-                },
-                backing: RbVmomi::VIM.VirtualEthernetCardNetworkBackingInfo(
-                  network: network_obj,
-                  deviceName: network_obj.name
-                )
-              )
-            )
-          ]
-        # This will update the exiting network to the new network
-        else
-          if network_obj.is_a? RbVmomi::VIM::DistributedVirtualPortgroup
-            Kitchen.logger.info format("Assigning network %s...", network_obj.pretty_path)
-
-            vds_obj = network_obj.config.distributedVirtualSwitch
-            Kitchen.logger.info format("Using vDS '%s' for network connectivity...", vds_obj.name)
-
-            network_device.backing = RbVmomi::VIM.VirtualEthernetCardDistributedVirtualPortBackingInfo(
-              port: RbVmomi::VIM.DistributedVirtualSwitchPortConnection(
-                portgroupKey: network_obj.key,
-                switchUuid: vds_obj.uuid
-              )
-            )
-          elsif network_obj.is_a? RbVmomi::VIM::Network
-            Kitchen.logger.info format("Assigning network %s...", options[:network_name])
-
-            network_device.backing = RbVmomi::VIM.VirtualEthernetCardNetworkBackingInfo(
-              deviceName: options[:network_name]
-            )
-          else
-            raise Support::CloneError.new(format("Unknown network type %s for network name %s", network_obj.class.to_s, options[:network_name]))
-          end
-
-          relocate_spec.deviceChange = [
-            RbVmomi::VIM.VirtualDeviceConfigSpec(
-              operation: RbVmomi::VIM::VirtualDeviceConfigSpecOperation("edit"),
-              device: network_device
-            ),
-          ]
-        end
+      if update_network?(network_device)
+        network_obj = fetch_network(dc)
+        relocate_spec.deviceChange = network_change_spec(network_device, network_obj)
       end
 
       # Set the folder to use
@@ -648,6 +678,8 @@ class Support
       end
 
       vm_customization if options[:vm_customization]
+
+      add_new_network_device(dc) if add_network?(network_device)
 
       # Start only if specified or customizations wanted; no need for instant clones as they start in running state
       if options[:poweron] && !options[:vm_customization].nil? && !instant_clone?

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -494,8 +494,7 @@ class Support
     #
     # The network_obj will be used as a backing for the network_device.
     def network_change_spec(network_device, network_obj, operation: :edit)
-      case network_obj
-      when RbVmomi::VIM::DistributedVirtualPortgroup
+      if network_obj.is_a? RbVmomi::VIM::DistributedVirtualPortgroup
         Kitchen.logger.info format("Assigning network %s...", network_obj.pretty_path)
 
         vds_obj = network_obj.config.distributedVirtualSwitch
@@ -507,7 +506,7 @@ class Support
             switchUuid: vds_obj.uuid
           )
         )
-      when RbVmomi::VIM::Network
+      elsif network_obj.is_a? RbVmomi::VIM::Network
         Kitchen.logger.info format("Assigning network %s...", options[:network_name])
 
         network_device.backing = RbVmomi::VIM.VirtualEthernetCardNetworkBackingInfo(

--- a/spec/unit/support/clone_vm_spec.rb
+++ b/spec/unit/support/clone_vm_spec.rb
@@ -197,13 +197,13 @@ describe Support::CloneVm do
 
     context "attaching a new vm" do
       before do
-        options[:network_name] = 'my-network'
+        options[:network_name] = "my-network"
 
         allow(subject).to receive(:network_device).and_return(nil)
       end
 
-      context '#add_network?' do
-        it 'should return true' do
+      context "#add_network?" do
+        it "should return true" do
           expect(subject.add_network?(nil)).to be_truthy
         end
       end

--- a/spec/unit/support/clone_vm_spec.rb
+++ b/spec/unit/support/clone_vm_spec.rb
@@ -194,5 +194,27 @@ describe Support::CloneVm do
         end
       end
     end
+
+    context "attaching a new vm" do
+      before do
+        options[:network_name] = 'my-network'
+
+        allow(subject).to receive(:network_device).and_return(nil)
+      end
+
+      context '#add_network?' do
+        it 'should return true' do
+          expect(subject.add_network?(nil)).to be_truthy
+        end
+      end
+
+      it "should call the reconfig vm task to add vm" do
+        expect(RbVmomi::VIM).to receive(:VirtualMachineConfigSpec)
+        expect(created_vm).to receive(:ReconfigVM_Task).and_return(created_vm_reconfigure_task)
+        expect(subject).to receive(:network_change_spec)
+
+        subject.clone
+      end
+    end
   end
 end


### PR DESCRIPTION
Signed-off-by: Ashique Saidalavi <ashique.saidalavi@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
If the VM template lacks a NIC then test-kitchen should be able to pass on NIC details via kitchen.yml and kitchen-vcenter should be able to call relevant vCenter API to add NIC in the cloned VM.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
