### PR TITLE
Bundle win32-security for windows platforms dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,8 @@ group :debug do
   gem "pry-stack_explorer"
   gem "rb-readline"
 end
+
+# This is a required dependency for windows platforms
+platforms :mswin, :mingw, :x64_mingw do
+  gem "win32-security"
+end


### PR DESCRIPTION
Signed-off-by: Ashique Saidalavi <ashique.saidalavi@progress.com>

<!--- Provide a short summary of your changes in the Title above -->
When we use this gem in windows platforms, it fails due to unmet dependency with the windows platform. The `net-ping` gem in dependent on win32-security in windows and that gem is never installed. So we are bundling the win32-security gem as well for the windows platforms only.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Bundle `win32-security` gem with kitcoen-vcenter to meet the requirements in windows platform.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
