### PR TITLE
Add vm name to initial clone log

### DIFF
--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -599,7 +599,7 @@ class Support
       # Set the folder to use
       dest_folder = options[:folder].nil? ? dc.vmFolder : options[:folder][:id]
 
-      Kitchen.logger.info format("Cloning '%s' to create the VM...", options[:template])
+      Kitchen.logger.info format("Cloning '%s' to create the %s VM...", options[:template], vm_name)
       if instant_clone?
         vcenter_data = vim.serviceInstance.content.about
         raise Support::CloneError.new("Instant clones only supported with vCenter 6.7 or higher") unless vcenter_data.version.to_f >= 6.7


### PR DESCRIPTION
## Description

This just adds the VM name to the initial log so it's easy to find the VM in vcenter before it's finished creating. This can be helpful for debugging.

## Related Issue

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
