### PR TITLE
[INFCT-53] Support for managing multiple networks

### DIFF
--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -567,7 +567,7 @@ class Support
 
       config_spec = RbVmomi::VIM.VirtualMachineConfigSpec(
         {
-          deviceChange: device_change
+          deviceChange: device_change,
         }
       )
 

--- a/spec/unit/support/clone_vm_spec.rb
+++ b/spec/unit/support/clone_vm_spec.rb
@@ -258,17 +258,17 @@ describe Support::CloneVm do
         expect { subject.clone }.not_to raise_error
       end
 
-      it 'network_change_spec should invoke twice' do
+      it "network_change_spec should invoke twice" do
         expect(subject).to receive(:network_change_spec).twice
 
         subject.clone
       end
 
-      it 'helper method should return correct values' do
+      it "helper method should return correct values" do
         expect(subject.add_network?).to be_truthy
         expect(subject.update_network?(network)).to be_truthy
-        expect(subject.networks_to_update.first[:name]).to eq 'my-network'
-        expect(subject.networks_to_add.first[:name]).to eq 'my-network-2'
+        expect(subject.networks_to_update.first[:name]).to eq "my-network"
+        expect(subject.networks_to_add.first[:name]).to eq "my-network-2"
       end
     end
   end


### PR DESCRIPTION
Signed-off-by: Ashique P S <Ashique.saidalavi@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
When creating a VM using the vCenter driver, the user can reconfigure the existing network or attach multiple networks.

The previous configuration for managing the networks was `network_name` which could be able to reconfigure the existing network when a new VM is created.
This configuration is now deprecated and the `networks` configuration is introduced to support the multi-network functionality.

Example Usage: 

```yaml
driver:
  # ... other settings
  networks:
    - name: VLAN-1
      operation: "edit"
    - name: VLAN-2
      operation: "add"
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/customer-bugs/issues/654
https://github.com/chef/kitchen-vcenter/issues/141

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
