### PR TITLE
Use rbvmomi2 gem

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -10,14 +10,6 @@ expeditor:
       timeout_in_minutes: 30
 
 steps:
-- label: run-lint-and-specs-ruby-2.6
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6-buster
-
 - label: run-lint-and-specs-ruby-2.7
   command:
     - .expeditor/run_linux_tests.sh rake
@@ -33,3 +25,11 @@ steps:
     executor:
       docker:
         image: ruby:3.0-buster
+
+- label: run-lint-and-specs-ruby-3.1
+  command:
+    - .expeditor/run_linux_tests.sh rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.1-buster

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0']
+        ruby: ['2.7', '3.0', '3.1']
     name: Chefstyle on Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/kitchen-vcenter.gemspec
+++ b/kitchen-vcenter.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["LICENSE", "lib/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.add_dependency "net-ping", ">= 2.0.0", "< 3.0"
-  spec.add_dependency "rbvmomi2", ">= 1.11", "< 4.0"
+  spec.add_dependency "rbvmomi2", ">= 3.5.0", "< 4.0"
   spec.add_dependency "test-kitchen", ">= 1.16", "< 4"
   spec.add_dependency "vsphere-automation-sdk", "~> 0.4"
 end

--- a/kitchen-vcenter.gemspec
+++ b/kitchen-vcenter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6"
 
   spec.add_dependency "net-ping", ">= 2.0.0", "< 3.0"
-  spec.add_dependency "rbvmomi", ">= 1.11", "< 4.0"
+  spec.add_dependency "rbvmomi2", ">= 1.11", "< 4.0"
   spec.add_dependency "test-kitchen", ">= 1.16", "< 4"
   spec.add_dependency "vsphere-automation-sdk", "~> 0.4"
 end


### PR DESCRIPTION
Signed-off-by: Ashique P S <Ashique.saidalavi@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The API wrapper gem used in kitchen-vcenter is `rbvmomi` and it is currently in the public archive and there isn't any development going on. Luckily someone from the community has forked this gem and fixed some of the known issues and published a new version as `rbvmomi2`. 

In this PR, updated the gem spec to use the new gem as a dependency. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
