### PR TITLE
fix issue if adding more disks than scsictrlunitnumber value

### DIFF
--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -375,6 +375,9 @@ class Support
         # Storage Controller and ID mapping
         controller = vm.config.hardware.device.select { |device| device.is_a? RbVmomi::VIM::VirtualSCSIController }.first
 
+        highest_id = vm.disks.map(&:unitNumber).max
+        next_id = highest_id
+
         add_disks.each_with_index do |disk_config, idx|
           # Default to Thin Provisioning and 10GB disk size
           disk_config[:type]    ||= :thin
@@ -405,8 +408,7 @@ class Support
 
           disk_spec.device.controllerKey = controller.key
 
-          highest_id = vm.disks.map(&:unitNumber).max
-          next_id = highest_id + idx + 1
+          next_id = next_id + 1
 
           # Avoid the SCSI controller ID
           next_id += 1 if next_id == controller.scsiCtlrUnitNumber

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -409,10 +409,9 @@ class Support
 
           disk_spec.device.controllerKey = controller.key
 
-          next_id +=
-
           # Avoid the SCSI controller ID
-          next_id += 1 if next_id == controller.scsiCtlrUnitNumber
+          next_id += (next_id == controller.scsiCtlrUnitNumber ? 2 : 1)
+
 
           # Theoretically could add another SCSI controller, but there are limits to what kitchen should support
           if next_id > 14

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -408,7 +408,7 @@ class Support
 
           disk_spec.device.controllerKey = controller.key
 
-          next_id = next_id + 1
+          next_id = +=
 
           # Avoid the SCSI controller ID
           next_id += 1 if next_id == controller.scsiCtlrUnitNumber

--- a/lib/support/clone_vm.rb
+++ b/lib/support/clone_vm.rb
@@ -375,6 +375,7 @@ class Support
         # Storage Controller and ID mapping
         controller = vm.config.hardware.device.select { |device| device.is_a? RbVmomi::VIM::VirtualSCSIController }.first
 
+        # Move these variables outside the loop so they persist
         highest_id = vm.disks.map(&:unitNumber).max
         next_id = highest_id
 
@@ -408,7 +409,7 @@ class Support
 
           disk_spec.device.controllerKey = controller.key
 
-          next_id = +=
+          next_id +=
 
           # Avoid the SCSI controller ID
           next_id += 1 if next_id == controller.scsiCtlrUnitNumber


### PR DESCRIPTION
add_disks fails if adding more disks than the value of `controller.scsiCtlrUnitNumber`

## Description
In my situation I was trying to add 7 disks to my template during `kitchen create`.  My template already has 2 disks to begin with.  When creating my VMs I found that `controller.scsi.CtlrUnitNumber = 7`.  When adding my disks and iterating through :Add_disks, line 412 would change `next_id` from 7 to 8.  However, when trying to add another disk after 7 `next_id` would be 8 again causing the create to fail. 

This code change moves `highest_id` and `next_id` outside of the loop and no longer relies on the `idx` variable to determine `next_id`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
