### PR TITLE
updating to newer images for tests

### DIFF
--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -11,6 +11,7 @@ echo "--- bundle install"
 
 bundle config --local path vendor/bundle
 bundle install --jobs=7 --retry=3
+bundle config set force_ruby_platform true
 
 echo "+++ bundle exec task"
 bundle exec $@

--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -11,7 +11,6 @@ echo "--- bundle install"
 
 bundle config --local path vendor/bundle
 bundle install --jobs=7 --retry=3
-bundle config set force_ruby_platform true
 
 echo "+++ bundle exec task"
 bundle exec $@

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -16,7 +16,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:3.1-buster
+        image: ruby:3.1
 
 - label: run-lint-and-specs-ruby-3.2
   command:
@@ -24,7 +24,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:3.2-buster
+        image: ruby:3.2
 
 - label: run-lint-and-specs-ruby-3.3
   command:

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ mkmf.log
 .chef
 local/
 .vscode/
+vendor/


### PR DESCRIPTION
This has the correct version of glibc which fixes the error:

```
<html>
<body>
<!--StartFragment-->
An error occurred while loading ./spec/unit/kitchen/driver/vcenter_spec.rb.
--
  | Failure/Error: require "rbvmomi"
  |  
  | LoadError:
  | /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by /workdir/vendor/bundle/ruby/3.1.0/gems/nokogiri-1.18.3-x86_64-linux-gnu/lib/nokogiri/3.1/nokogiri.so) - /workdir/vendor/bundle/ruby/3.1.0/gems/nokogiri-1.18.3-x86_64-linux-gnu/lib/nokogiri/3.1/nokogiri.so
  | # ./vendor/bundle/ruby/3.1.0/gems/nokogiri-1.18.3-x86_64-linux-gnu/lib/nokogiri/extension.rb:7:in `require_relative'
  | # ./vendor/bundle/ruby/3.1.0/gems/nokogiri-1.18.3-x86_64-linux-gnu/lib/nokogiri/extension.rb:7:in `<top (required)>'
  | # ./vendor/bundle/ruby/3.1.0/gems/nokogiri-1.18.3-x86_64-linux-gnu/lib/nokogiri.rb:8:in `require_relative'
  | # ./vendor/bundle/ruby/3.1.0/gems/nokogiri-1.18.3-x86_64-linux-gnu/lib/nokogiri.rb:8:in `<top (required)>'
  | # ./vendor/bundle/ruby/3.1.0/gems/rbvmomi2-3.8.0/lib/rbvmomi/trivial_soap.rb:7:in `require'
  | # ./vendor/bundle/ruby/3.1.0/gems/rbvmomi2-3.8.0/lib/rbvmomi/trivial_soap.rb:7:in `<top (required)>'
  | # ./vendor/bundle/ruby/3.1.0/gems/rbvmomi2-3.8.0/lib/rbvmomi/connection.rb:7:in `require_relative'
  | # ./vendor/bundle/ruby/3.1.0/gems/rbvmomi2-3.8.0/lib/rbvmomi/connection.rb:7:in `<top (required)>'
  | # ./vendor/bundle/ruby/3.1.0/gems/rbvmomi2-3.8.0/lib/rbvmomi.rb:14:in `require_relative'
  | # ./vendor/bundle/ruby/3.1.0/gems/rbvmomi2-3.8.0/lib/rbvmomi.rb:14:in `<top (required)>'
  | # ./lib/kitchen/driver/vcenter.rb:19:in `require'
  | # ./lib/kitchen/driver/vcenter.rb:19:in `<top (required)>'
  | # ./spec/unit/kitchen/driver/vcenter_spec.rb:1:in `require'
  | # ./spec/unit/kitchen/driver/vcenter_spec.rb:1:in `<top (required)>'
  |  
  | ERROR: It looks like you're trying to use Nokogiri as a precompiled native gem on a system
  | with an unsupported version of glibc.
  |  
  | /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by /workdir/vendor/bundle/ruby/3.1.0/gems/nokogiri-1.18.3-x86_64-linux-gnu/lib/nokogiri/3.1/nokogiri.so) - /workdir/vendor/bundle/ruby/3.1.0/gems/nokogiri-1.18.3-x86_64-linux-gnu/lib/nokogiri/3.1/nokogiri.so
  |  
  | If that's the case, then please install Nokogiri via the `ruby` platform gem:
  | gem install nokogiri --platform=ruby
  | or:
  | bundle config set force_ruby_platform true
  |  
  | Please visit https://nokogiri.org/tutorials/installing_nokogiri.html for more help.
  ```

