### PR TITLE
Update handling of windows timezone to account for usage of dword/signed integers by vCenter 8

### DIFF
--- a/lib/support/guest_customization.rb
+++ b/lib/support/guest_customization.rb
@@ -195,7 +195,7 @@ class Support
 
       RbVmomi::VIM::CustomizationSysprep.new(
         guiUnattended: RbVmomi::VIM::CustomizationGuiUnattended.new(
-          timeZone: timezone.to_i || DEFAULT_WINDOWS_TIMEZONE,
+          timeZone: windows_timezone_convert(timezone || DEFAULT_WINDOWS_TIMEZONE),
           autoLogon: false,
           autoLogonCount: 1,
           password: customization_pass
@@ -242,9 +242,36 @@ class Support
     def valid_windows_timezone?(input)
       # Accept decimals and hex
       # See https://support.microsoft.com/en-us/help/973627/microsoft-time-zone-index-values
-      windows_timezone_pattern = /^([0-9]+|0x[0-9a-fA-F]+)$/
+      windows_timezone_pattern = /^((-){,1}[0-9]+|0x[0-9a-fA-F]+)$/
 
       input.to_s.match? windows_timezone_pattern
+    end
+
+    # convert the value provided to a signed int
+    #
+    # @param input - Value to convert
+    # @returns [Integer] of converted value
+    def windows_timezone_convert(input)
+        mid = 2**(32-1)
+        max = 2**32
+        #ret = input
+        if input.kind_of?(String)
+            if input.match? /^0x[0-9a-fA-F]+$/
+                input = input.to_i(16)
+            else
+                input = input.to_i()
+            end
+        end
+        if input.kind_of?(Integer)
+            input = input
+        else
+            puts "not an integer"
+            input = input.to_i(16)
+        end
+        if input >= mid
+            input = input - max
+        end
+        input
     end
 
     # Check for format of Windows Product IDs

--- a/lib/support/guest_customization.rb
+++ b/lib/support/guest_customization.rb
@@ -265,7 +265,6 @@ class Support
         if input.kind_of?(Integer)
             input = input
         else
-            puts "not an integer"
             input = input.to_i(16)
         end
         if input >= mid

--- a/lib/support/guest_customization.rb
+++ b/lib/support/guest_customization.rb
@@ -252,25 +252,24 @@ class Support
     # @param input - Value to convert
     # @returns [Integer] of converted value
     def windows_timezone_convert(input)
-        mid = 2**(32-1)
-        max = 2**32
-        #ret = input
-        if input.kind_of?(String)
-            if input.match? /^0x[0-9a-fA-F]+$/
-                input = input.to_i(16)
-            else
-                input = input.to_i()
-            end
-        end
-        if input.kind_of?(Integer)
-            input = input
+      mid = 2**(32 - 1)
+      max = 2**32
+      if input.is_a?(String)
+        if input.match?(/^0x[0-9a-fA-F]+$/)
+          input = input.to_i(16)
         else
-            input = input.to_i(16)
+          input = input.to_i
         end
-        if input >= mid
-            input = input - max
-        end
-        input
+      end
+      if input.is_a?(Integer)
+        input = input
+      else
+        input = input.to_i(16)
+      end
+      if input >= mid
+        input -= max
+      end
+      input
     end
 
     # Check for format of Windows Product IDs

--- a/spec/unit/support/clone_vm_spec.rb
+++ b/spec/unit/support/clone_vm_spec.rb
@@ -271,5 +271,41 @@ describe Support::CloneVm do
         expect(subject.networks_to_add.first[:name]).to eq "my-network-2"
       end
     end
+    windows_timezone_tests = [
+      ["Coordinated Universal Time", [0x80000050, "0x80000050", "-2147483568", -2147483568], -2147483568],
+      ["Eastern Time (US & Canada)", ["35", 35, 0x23, "0x23"], 35],
+      ["Central Time (US & Canada)", ["20", 20, 0x14, "0x14"], 20],
+      ["Dublin, Edinburgh, Lisbon, London", ["85", 85, "0x55", 0x55], 85],
+      ["Istanbul", [-2147483560, "-2147483560", 0x80000058, "0x80000058"], -2147483560],
+    ]
+    windows_timezone_tests.each do |this_timezone|
+      context "when windows guest_customization timezone for \"#{this_timezone[0]}\" is provided" do
+        this_timezone[1].each do |val|
+          before do
+            allow(event_manager).to receive(:QueryEvents).and_return([RbVmomi::VIM::CustomizationSucceeded()])
+            options[:vm_os] = "windows"
+            options[:guest_customization] = {
+              timeout_task: 1,
+              timezone: val,
+              product_id: "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
+              org_name: "chef",
+              dns_domain: "chef.io",
+              dns_server_list: [],
+              dns_suffix_list: [],
+            }
+          end
+          it "properly validates the passed timezone" do
+            expect(subject.valid_windows_timezone?(options[:guest_customization][:timezone])).to be_truthy
+          end
+          it "properly converts the passed timezone to a 32-bit signed integer" do
+            expect(subject.windows_timezone_convert(options[:guest_customization][:timezone])).to eq this_timezone[2]
+          end
+          it "includes guest customizaiton with the correct timezone code" do
+            expect(source_vm).to receive(:CloneVM_Task).with(spec: a_hash_including(customization: a_hash_including(identity: a_hash_including(guiUnattended: a_hash_including(timeZone: this_timezone[2])))), folder: folder_id, name: vm_name).and_return(clone_vm_task)
+            subject.clone
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/unit/support/clone_vm_spec.rb
+++ b/spec/unit/support/clone_vm_spec.rb
@@ -277,6 +277,7 @@ describe Support::CloneVm do
       ["Central Time (US & Canada)", ["20", 20, 0x14, "0x14"], 20],
       ["Dublin, Edinburgh, Lisbon, London", ["85", 85, "0x55", 0x55], 85],
       ["Istanbul", [-2147483560, "-2147483560", 0x80000058, "0x80000058"], -2147483560],
+      ["Casablanca", [-2147483571, "-2147483571", 0x8000004d, "0x8000004d"], -2147483571],
     ]
     windows_timezone_tests.each do |this_timezone|
       context "when windows guest_customization timezone for \"#{this_timezone[0]}\" is provided" do

--- a/spec/unit/support/clone_vm_spec.rb
+++ b/spec/unit/support/clone_vm_spec.rb
@@ -271,6 +271,7 @@ describe Support::CloneVm do
         expect(subject.networks_to_add.first[:name]).to eq "my-network-2"
       end
     end
+
     windows_timezone_tests = [
       ["Coordinated Universal Time", [0x80000050, "0x80000050", "-2147483568", -2147483568], -2147483568],
       ["Eastern Time (US & Canada)", ["35", 35, 0x23, "0x23"], 35],
@@ -295,13 +296,13 @@ describe Support::CloneVm do
               dns_suffix_list: [],
             }
           end
-          it "properly validates the passed timezone" do
+          it "helper method properly validates the passed timezone" do
             expect(subject.valid_windows_timezone?(options[:guest_customization][:timezone])).to be_truthy
           end
-          it "properly converts the passed timezone to a 32-bit signed integer" do
+          it "helper method properly converts the passed timezone to a 32-bit signed integer" do
             expect(subject.windows_timezone_convert(options[:guest_customization][:timezone])).to eq this_timezone[2]
           end
-          it "includes guest customizaiton with the correct timezone code" do
+          it "sets guest customization data with the correct timezone code" do
             expect(source_vm).to receive(:CloneVM_Task).with(spec: a_hash_including(customization: a_hash_including(identity: a_hash_including(guiUnattended: a_hash_including(timeZone: this_timezone[2])))), folder: folder_id, name: vm_name).and_return(clone_vm_task)
             subject.clone
           end


### PR DESCRIPTION
vCenter 8 expects dword/signed integer versions of the timezone hex values for windows, i.e. 0x80000050 (UTC time) when converted to an integer should be "-2147483568" not "2147483728" as the basic "to_i" returns

This PR allows specifying negative integer numbers as well as properly converting hex values.  Additionally, if either type is passed as a string representation, the value is properly converted.

## Description
When attempting to customize a Windows VM's timezone, the use of "0x80000050" (as an example) no longer properly sets the timezone to "UTC".  vCenter expects the a signed integer version, where 0x8000050 is -2147483568.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#189 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
