### PR TITLE
fix: bump tk dep to allow tk 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For information on contributing to this project see <https://github.com/chef/che
 
 ## Development
 
-- Report issues/questions/feature requests on [GitHub Issues][issues]
+* Report issues/questions/feature requests on [GitHub Issues][issues]
 
 Pull requests are very welcome! Make sure your patches are well tested. Ideally create a topic branch for every separate change you make. For example:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For information on contributing to this project see <https://github.com/chef/che
 
 ## Development
 
-* Report issues/questions/feature requests on [GitHub Issues][issues]
+- Report issues/questions/feature requests on [GitHub Issues][issues]
 
 Pull requests are very welcome! Make sure your patches are well tested. Ideally create a topic branch for every separate change you make. For example:
 

--- a/kitchen-vcenter.gemspec
+++ b/kitchen-vcenter.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "net-ping", ">= 2.0.0", "< 3.0"
   spec.add_dependency "rbvmomi2", ">= 3.5.0", "< 4.0"
-  spec.add_dependency "test-kitchen", ">= 1.16", "< 4"
+  spec.add_dependency "test-kitchen", ">= 1.16", "< 5"
   spec.add_dependency "vsphere-automation-sdk", "~> 0.4"
 end


### PR DESCRIPTION
## Description

bump tk dep to allow tk 4

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
